### PR TITLE
Add Localization Patch manifests (5 languages)

### DIFF
--- a/modManifests/LocalizationPatch.French.json
+++ b/modManifests/LocalizationPatch.French.json
@@ -1,0 +1,38 @@
+{
+  "id": "LocalizationPatch.French",
+  "displayName": "French Localization Patch",
+  "description": "French (Français) translation for Nuclear Option. Translates UI, encyclopedia, hints, and tooltips — 1,427 entries.",
+  "tags": [
+    "mod",
+    "Localization"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/9138noms/NuclearOption-FrenchPatch"
+    }
+  ],
+  "authors": [
+    "9138noms"
+  ],
+  "githubOwner": "9138noms",
+  "githubRepoName": "NuclearOption-FrenchPatch",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "LocalizationPatch_fr.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.32",
+      "downloadUrl": "https://github.com/9138noms/NuclearOption-FrenchPatch/releases/download/v1.0.0/LocalizationPatch_fr.zip",
+      "hash": "sha256:1815c458aee9755bc52c1a6ea1d51e07bda1ae58c2f4b5b4cb0e27a9fa43d089",
+      "incompatibilities": [
+        { "id": "LocalizationPatch.Korean", "version": "1.0.0" },
+        { "id": "LocalizationPatch.German", "version": "1.0.0" },
+        { "id": "LocalizationPatch.Russian", "version": "1.0.0" },
+        { "id": "LocalizationPatch.Spanish", "version": "1.0.0" }
+      ]
+    }
+  ]
+}

--- a/modManifests/LocalizationPatch.German.json
+++ b/modManifests/LocalizationPatch.German.json
@@ -1,0 +1,38 @@
+{
+  "id": "LocalizationPatch.German",
+  "displayName": "German Localization Patch",
+  "description": "German (Deutsch) translation for Nuclear Option. Translates UI, encyclopedia, hints, and tooltips — 1,427 entries.",
+  "tags": [
+    "mod",
+    "Localization"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/9138noms/NuclearOption-GermanPatch"
+    }
+  ],
+  "authors": [
+    "9138noms"
+  ],
+  "githubOwner": "9138noms",
+  "githubRepoName": "NuclearOption-GermanPatch",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "LocalizationPatch_de.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.32",
+      "downloadUrl": "https://github.com/9138noms/NuclearOption-GermanPatch/releases/download/v1.0.0/LocalizationPatch_de.zip",
+      "hash": "sha256:a26188459cc00e5766878611f9e0ab04d768479856a1b46d4f897f9b226a14c7",
+      "incompatibilities": [
+        { "id": "LocalizationPatch.Korean", "version": "1.0.0" },
+        { "id": "LocalizationPatch.Russian", "version": "1.0.0" },
+        { "id": "LocalizationPatch.Spanish", "version": "1.0.0" },
+        { "id": "LocalizationPatch.French", "version": "1.0.0" }
+      ]
+    }
+  ]
+}

--- a/modManifests/LocalizationPatch.Korean.json
+++ b/modManifests/LocalizationPatch.Korean.json
@@ -1,0 +1,38 @@
+{
+  "id": "LocalizationPatch.Korean",
+  "displayName": "Korean Localization Patch",
+  "description": "Korean (한국어) translation for Nuclear Option. Translates UI, encyclopedia, hints, and tooltips — 1,427 entries.",
+  "tags": [
+    "mod",
+    "Localization"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/9138noms/NuclearOption-KoreanPatch"
+    }
+  ],
+  "authors": [
+    "9138noms"
+  ],
+  "githubOwner": "9138noms",
+  "githubRepoName": "NuclearOption-KoreanPatch",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "LocalizationPatch_ko.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.32",
+      "downloadUrl": "https://github.com/9138noms/NuclearOption-KoreanPatch/releases/download/v1.0.0/LocalizationPatch_ko.zip",
+      "hash": "sha256:1a9715f750c465c46a03366208b881ffd45afe282dee5f591676f2522cf4c4ce",
+      "incompatibilities": [
+        { "id": "LocalizationPatch.German", "version": "1.0.0" },
+        { "id": "LocalizationPatch.Russian", "version": "1.0.0" },
+        { "id": "LocalizationPatch.Spanish", "version": "1.0.0" },
+        { "id": "LocalizationPatch.French", "version": "1.0.0" }
+      ]
+    }
+  ]
+}

--- a/modManifests/LocalizationPatch.Russian.json
+++ b/modManifests/LocalizationPatch.Russian.json
@@ -1,0 +1,38 @@
+{
+  "id": "LocalizationPatch.Russian",
+  "displayName": "Russian Localization Patch",
+  "description": "Russian (Русский) translation for Nuclear Option. Translates UI, encyclopedia, hints, and tooltips — 1,427 entries.",
+  "tags": [
+    "mod",
+    "Localization"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/9138noms/NuclearOption-RussianPatch"
+    }
+  ],
+  "authors": [
+    "9138noms"
+  ],
+  "githubOwner": "9138noms",
+  "githubRepoName": "NuclearOption-RussianPatch",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "LocalizationPatch_ru.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.32",
+      "downloadUrl": "https://github.com/9138noms/NuclearOption-RussianPatch/releases/download/v1.0.0/LocalizationPatch_ru.zip",
+      "hash": "sha256:f58e3f9891139f021c863c4aeb51525cc09e24e27b63f4a83aa4e0d754b0c4e9",
+      "incompatibilities": [
+        { "id": "LocalizationPatch.Korean", "version": "1.0.0" },
+        { "id": "LocalizationPatch.German", "version": "1.0.0" },
+        { "id": "LocalizationPatch.Spanish", "version": "1.0.0" },
+        { "id": "LocalizationPatch.French", "version": "1.0.0" }
+      ]
+    }
+  ]
+}

--- a/modManifests/LocalizationPatch.Spanish.json
+++ b/modManifests/LocalizationPatch.Spanish.json
@@ -1,0 +1,38 @@
+{
+  "id": "LocalizationPatch.Spanish",
+  "displayName": "Spanish Localization Patch",
+  "description": "Spanish (Español) translation for Nuclear Option. Translates UI, encyclopedia, hints, and tooltips — 1,427 entries.",
+  "tags": [
+    "mod",
+    "Localization"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/9138noms/NuclearOption-SpanishPatch"
+    }
+  ],
+  "authors": [
+    "9138noms"
+  ],
+  "githubOwner": "9138noms",
+  "githubRepoName": "NuclearOption-SpanishPatch",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "LocalizationPatch_es.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.32",
+      "downloadUrl": "https://github.com/9138noms/NuclearOption-SpanishPatch/releases/download/v1.0.0/LocalizationPatch_es.zip",
+      "hash": "sha256:e81a713aece7d737039ebc264cbc706dd7f1b68588a137e518e4031627504843",
+      "incompatibilities": [
+        { "id": "LocalizationPatch.Korean", "version": "1.0.0" },
+        { "id": "LocalizationPatch.German", "version": "1.0.0" },
+        { "id": "LocalizationPatch.Russian", "version": "1.0.0" },
+        { "id": "LocalizationPatch.French", "version": "1.0.0" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## New Mod Manifests: Localization Patch

Adding 5 localization patch manifests for Nuclear Option:

| Manifest | Language | Repository |
|----------|----------|------------|
| `LocalizationPatch.Korean` | Korean (한국어) | [NuclearOption-KoreanPatch](https://github.com/9138noms/NuclearOption-KoreanPatch) |
| `LocalizationPatch.German` | German (Deutsch) | [NuclearOption-GermanPatch](https://github.com/9138noms/NuclearOption-GermanPatch) |
| `LocalizationPatch.Russian` | Russian (Русский) | [NuclearOption-RussianPatch](https://github.com/9138noms/NuclearOption-RussianPatch) |
| `LocalizationPatch.Spanish` | Spanish (Español) | [NuclearOption-SpanishPatch](https://github.com/9138noms/NuclearOption-SpanishPatch) |
| `LocalizationPatch.French` | French (Français) | [NuclearOption-FrenchPatch](https://github.com/9138noms/NuclearOption-FrenchPatch) |

**Details:**
- Each patch translates 1,427 entries (UI, encyclopedia, hints, tooltips)
- BepInEx 5 plugin
- Game version: 0.32
- All 5 patches are marked as mutually incompatible (only one language at a time)
- Auto-update enabled via GitHub Releases (tag: v1.0.0)