### PR TITLE
Add AI Aircraft Limit mod

### DIFF
--- a/modManifests/AIAircraftLimit.json
+++ b/modManifests/AIAircraftLimit.json
@@ -1,0 +1,32 @@
+{
+  "id": "AIAircraftLimit",
+  "displayName": "AI Aircraft Limit",
+  "description": "Increase the maximum active AI aircraft per faction. Extends mission editor slider up to 128 and optionally overrides the limit at runtime.",
+  "tags": [
+    "mod",
+    "QoL"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/9138noms/NuclearOption-AIAircraftLimit"
+    }
+  ],
+  "authors": [
+    "9138noms"
+  ],
+  "githubOwner": "9138noms",
+  "githubRepoName": "NuclearOption-AIAircraftLimit",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "AIAircraftLimit-v1.1.0.zip",
+      "version": "1.1.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.32",
+      "downloadUrl": "https://github.com/9138noms/NuclearOption-AIAircraftLimit/releases/download/v1.1.0/AIAircraftLimit-v1.1.0.zip",
+      "hash": null
+    }
+  ]
+}


### PR DESCRIPTION
Adds manifest for AI Aircraft Limit mod.

- Extends mission editor AI aircraft slider max (up to 128)
- Optional config override for runtime limit
- Works in singleplayer & multiplayer (host only)

GitHub: https://github.com/9138noms/NuclearOption-AIAircraftLimit