### PR TITLE
Re-add AtomicFramework and NuclearVOIP

### DIFF
--- a/modManifests/AtomicFramework.json
+++ b/modManifests/AtomicFramework.json
@@ -1,7 +1,7 @@
 {
   "id": "AtomicFramework",
   "displayName": "AtomicFramework",
-  "description": "Modding framework and utilities for Nuclear Option",
+  "description": "Modding framework and utilities for Nuclear Option. Note: The NOMNOM compatible version has some features removed.",
   "tags": [
     "mod",
     "QoL",

--- a/modManifests/AtomicFramework.json
+++ b/modManifests/AtomicFramework.json
@@ -1,0 +1,41 @@
+{
+  "id": "AtomicFramework",
+  "displayName": "AtomicFramework",
+  "description": "Modding framework and utilities for Nuclear Option",
+  "tags": [
+    "mod",
+    "QoL",
+    "multiplayer"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/TYKUHN2/AtomicFramework"
+    },
+    {
+      "name": "bugs",
+      "url": "https://github.com/TYKUHN2/AtomicFramework/issues"
+    },
+    {
+      "name": "security",
+      "url": "https://github.com/TYKUHN2/AtomicFramework/security"
+    }
+  ],
+  "authors": [
+    "TYKUHN2"
+  ],
+  "githubOwner": "TYKUHN2",
+  "githubRepoName": "AtomicFramework",
+  "autoUpdateArtifacts": "False",
+  "artifacts": [
+    {
+      "fileName": "AtomicFramework-NOMNOM.7z",
+      "version": "0.2.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.32.6",
+      "downloadUrl": "https://github.com/TYKUHN2/AtomicFramework/releases/download/v0.2.0/AtomicFramework-NOMNOM.7z",
+      "hash": null
+    }
+  ]
+}

--- a/modManifests/NuclearVOIP.json
+++ b/modManifests/NuclearVOIP.json
@@ -1,0 +1,43 @@
+{
+  "id": "NuclearVOIP",
+  "displayName": "NuclearVOIP",
+  "description": "Adds in game voice chat to Nuclear Option",
+  "tags": [
+    "mod",
+    "QoL",
+    "multiplayer"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/TYKUHN2/NuclearVOIP"
+    },
+    {
+      "name": "bugs",
+      "url": "https://github.com/TYKUHN2/NuclearVOIP/issues"
+    }
+  ],
+  "authors": [
+    "TYKUHN2"
+  ],
+  "githubOwner": "TYKUHN2",
+  "githubRepoName": "NuclearVOIP",
+  "autoUpdateArtifacts": "False",
+  "artifacts": [
+    {
+      "fileName": "NuclearVOIP-NOMNOM.7z",
+      "version": "0.5.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.32.6",
+      "downloadUrl": "https://github.com/TYKUHN2/NuclearVOIP/releases/download/v0.5.0/NuclearVOIP-NOMNOM.7z",
+      "hash": null,
+	  "dependencies": [
+		{
+			"id": "AtomicFramework",
+			"version": "0.2.0"
+		}
+	  ]
+    }
+  ]
+}


### PR DESCRIPTION
Artifacts require manual processing to ensure support, so autoupdating is not available.