### PR TITLE
Add NuclearOptionControllerTuner manifest

### DIFF
--- a/modManifests/NuclearOptionControllerTuner.json
+++ b/modManifests/NuclearOptionControllerTuner.json
@@ -1,0 +1,30 @@
+{
+  "id": "NuclearOptionControllerTuner",
+  "displayName": "Nuclear Option Controller Tuner",
+  "description": "Adds per-axis response curves (Linear, Power, SCurve, Logistic, Cubic) for any gamepad. Tune deadzone, saturation, shape, sensitivity, and inversion individually for Pitch, Roll, Yaw, Pan View, and Tilt View. Works with DualSense, Xbox controllers, generic gamepads, joysticks, and rudder pedals via Rewired. Keyboard and mouse pass through untouched.",
+  "tags": ["QoL"],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/TheDEMIKus/Nuclear-Option-Controller-Tuner-Mod"
+    },
+    {
+      "name": "issues",
+      "url": "https://github.com/TheDEMIKus/Nuclear-Option-Controller-Tuner-Mod/issues"
+    }
+  ],
+  "authors": ["TheDEMIKus"],
+  "githubOwner": "TheDEMIKus",
+  "githubRepoName": "Nuclear-Option-Controller-Tuner-Mod",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "type": "plugin",
+      "fileName": "NuclearOptionControllerTuner-1.0.0.zip",
+      "downloadUrl": "https://github.com/TheDEMIKus/Nuclear-Option-Controller-Tuner-Mod/releases/download/v1.0.0/NuclearOptionControllerTuner-1.0.0.zip",
+      "gameVersion": "0.33.3",
+      "version": "1.0.0",
+      "category": "Release"
+    }
+  ]
+}


### PR DESCRIPTION
Adding manifest for **Nuclear Option Controller Tuner** — a BepInEx 5
plugin that adds per-axis response curves for gamepads.

- Five curve types: Linear, Power, SCurve, Logistic, Cubic
- Per-axis: deadzone, saturation, shape, sensitivity, invert
- Whitelisted axes: Pitch, Roll, Yaw, Pan View, Tilt View
- Works for any controller (DualSense, Xbox, generic gamepads, joysticks, rudder pedals)

**Repo:** https://github.com/TheDEMIKus/Nuclear-Option-Controller-Tuner-Mod
**Release:** https://github.com/TheDEMIKus/Nuclear-Option-Controller-Tuner-Mod/releases/tag/v1.0.0
**Game version:** 0.33.3