### PR TITLE
Update Ibis Door Gun Toggle to v1.7.66

### DIFF
--- a/modManifests/IbisDoorGunToggle.json
+++ b/modManifests/IbisDoorGunToggle.json
@@ -21,12 +21,12 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "IbisDoorGunToggle-1.7.56.zip",
-      "version": "1.7.56",
+      "fileName": "IbisDoorGunToggle-1.7.66.zip",
+      "version": "1.7.66",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/Rendresen/Ibis-Door-Gun-Toggle/releases/download/v1.7.56/IbisDoorGunToggle-1.7.56.zip",
+      "downloadUrl": "https://github.com/Rendresen/Ibis-Door-Gun-Toggle/releases/download/v1.7.66/IbisDoorGunToggle-1.7.66.zip"
       "hash": null
     }
   ],

--- a/modManifests/IbisDoorGunToggle.json
+++ b/modManifests/IbisDoorGunToggle.json
@@ -26,7 +26,7 @@
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/Rendresen/Ibis-Door-Gun-Toggle/releases/download/v1.7.66/IbisDoorGunToggle-1.7.66.zip"
+      "downloadUrl": "https://github.com/Rendresen/Ibis-Door-Gun-Toggle/releases/download/v1.7.66/IbisDoorGunToggle-1.7.66.zip",
       "hash": null
     }
   ],


### PR DESCRIPTION
Updates Ibis Door Gun Toggle to v1.7.66.

Release:
https://github.com/Rendresen/Ibis-Door-Gun-Toggle/releases/tag/v1.7.66