### PR TITLE
Add Ibis Belly Turret Cargo Hook Patch

### DIFF
--- a/modManifests/IbisBellyTurretCargoHookPatch.json
+++ b/modManifests/IbisBellyTurretCargoHookPatch.json
@@ -21,12 +21,12 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "IbisBellyTurretCargoHookPatch-0.1.9.zip",
-      "version": "0.1.9",
+      "fileName": "IbisBellyTurretCargoHookPatch-0.1.10.zip",
+      "version": "0.1.10",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/Rendresen/Ibis-Belly-Turret-Cargo-Hook-Patch/releases/download/v0.1.9/IbisBellyTurretCargoHookPatch-0.1.9.zip",
+      "downloadUrl": "https://github.com/Rendresen/Ibis-Belly-Turret-Cargo-Hook-Patch/releases/download/v0.1.10/IbisBellyTurretCargoHookPatch-0.1.10.zip",
       "hash": "",
       "dependencies": [
         {

--- a/modManifests/IbisBellyTurretCargoHookPatch.json
+++ b/modManifests/IbisBellyTurretCargoHookPatch.json
@@ -21,12 +21,12 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "IbisBellyTurretCargoHookPatch-0.2.1.zip",
-      "version": "0.2.1",
+      "fileName": "IbisBellyTurretCargoHookPatch-0.2.3.zip",
+      "version": "0.2.3",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/Rendresen/Ibis-Belly-Turret-Cargo-Hook-Patch/releases/download/v0.2.1/IbisBellyTurretCargoHookPatch-0.2.1.zip",
+      "downloadUrl": "https://github.com/Rendresen/Ibis-Belly-Turret-Cargo-Hook-Patch/releases/download/v0.2.3/IbisBellyTurretCargoHookPatch-0.2.3.zip",
       "hash": "",
       "dependencies": [
         {

--- a/modManifests/IbisBellyTurretCargoHookPatch.json
+++ b/modManifests/IbisBellyTurretCargoHookPatch.json
@@ -21,12 +21,12 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "IbisBellyTurretCargoHookPatch-0.1.10.zip",
-      "version": "0.1.10",
+      "fileName": "IbisBellyTurretCargoHookPatch-0.2.1.zip",
+      "version": "0.2.1",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/Rendresen/Ibis-Belly-Turret-Cargo-Hook-Patch/releases/download/v0.1.10/IbisBellyTurretCargoHookPatch-0.1.10.zip",
+      "downloadUrl": "https://github.com/Rendresen/Ibis-Belly-Turret-Cargo-Hook-Patch/releases/download/v0.2.1/IbisBellyTurretCargoHookPatch-0.2.1.zip",
       "hash": "",
       "dependencies": [
         {

--- a/modManifests/IbisBellyTurretCargoHookPatch.json
+++ b/modManifests/IbisBellyTurretCargoHookPatch.json
@@ -1,0 +1,39 @@
+{
+  "id": "IbisBellyTurretCargoHookPatch",
+  "displayName": "Ibis Belly Turret Cargo Hook Patch",
+  "description": "QoL-compatible UH-90 Ibis patch that keeps QoL's belly turret slot, removes CargoHook from that slot, and adds a separate cargo-hook-only slot near the original cargo hook position.",
+  "tags": [
+    "mod",
+    "Aircraft",
+    "QoL"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/Rendresen/Ibis-Belly-Turret-Cargo-Hook-Patch"
+    }
+  ],
+  "authors": [
+    "Rendresen"
+  ],
+  "githubOwner": "Rendresen",
+  "githubRepoName": "Ibis-Belly-Turret-Cargo-Hook-Patch",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "IbisBellyTurretCargoHookPatch-0.1.9.zip",
+      "version": "0.1.9",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/Rendresen/Ibis-Belly-Turret-Cargo-Hook-Patch/releases/download/v0.1.9/IbisBellyTurretCargoHookPatch-0.1.9.zip",
+      "hash": "",
+      "dependencies": [
+        {
+          "id": "QoL",
+          "version": "1.7.1.0"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds NOMNOM manifest for Ibis Belly Turret Cargo Hook Patch.

This is a QoL-compatible UH-90 Ibis patch. QoL changes the Ibis cargo hook slot into a forward-shifted Ventral Mount for belly turrets. This patch preserves that Ventral Mount for belly turret weapons, removes CargoHook from it, and adds a new cargo-hook-only slot near the original cargo hook position.

Release:
- v0.1.9
- GitHub release asset: IbisBellyTurretCargoHookPatch-0.1.9.zip

Requirements:
- Nuclear Option
- BepInEx 5
- QoL

Dependency:
- Uses NOMNOM dependency id `QoL`
- Minimum dependency version set to `1.7.1.0`, matching QoL's current NOMNOM artifact for `qol_1.1.7.1.dll`.

Tested behavior:
- Ventral Mount keeps QoL belly turret options.
- Ventral Mount no longer offers CargoHook.
- New Cargo Hook slot offers CargoHook only.