### PR TITLE
Add ChicaneWingDelete manifest

### DIFF
--- a/modManifests/ChicaneWingDelete.json
+++ b/modManifests/ChicaneWingDelete.json
@@ -1,0 +1,33 @@
+{
+  "id": "ChicaneWingDelete",
+  "displayName": "Chicane Wing Delete",
+  "description": "Removes the Chicane's external wings when no wing payload is equipped, while preserving QoL/vanilla RCS behavior.",
+  "tags": [
+    "mod",
+    "Aircraft",
+    "QoL"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/Rendresen/ChicaneWingDelete"
+    }
+  ],
+  "authors": [
+    "Rendresen"
+  ],
+  "githubOwner": "Rendresen",
+  "githubRepoName": "ChicaneWingDelete",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "ChicaneWingDelete-0.9.3.zip",
+      "version": "0.9.3",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/Rendresen/ChicaneWingDelete/releases/download/v0.9.3/ChicaneWingDelete-0.9.3.zip",
+      "hash": null
+    }
+  ]
+}

--- a/modManifests/ChicaneWingDelete.json
+++ b/modManifests/ChicaneWingDelete.json
@@ -21,12 +21,12 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "ChicaneWingDelete-1.2.4.zip",
-      "version": "1.2.4",
+      "fileName": "ChicaneWingDelete-1.3.9.zip",
+      "version": "1.3.9",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/Rendresen/ChicaneWingDelete/releases/download/v1.2.4/ChicaneWingDelete-1.2.4.zip",
+      "downloadUrl": "https://github.com/Rendresen/ChicaneWingDelete/releases/download/v1.3.9/ChicaneWingDelete-1.3.9.zip",
       "hash": null
     }
   ]

--- a/modManifests/ChicaneWingDelete.json
+++ b/modManifests/ChicaneWingDelete.json
@@ -21,12 +21,12 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "ChicaneWingDelete-1.3.9.zip",
-      "version": "1.3.9",
+      "fileName": "ChicaneWingDelete-1.4.0.zip",
+      "version": "1.4.0",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/Rendresen/ChicaneWingDelete/releases/download/v1.3.9/ChicaneWingDelete-1.3.9.zip",
+      "downloadUrl": "https://github.com/Rendresen/ChicaneWingDelete/releases/download/v1.4.0/ChicaneWingDelete-1.4.0.zip",
       "hash": null
     }
   ]

--- a/modManifests/ChicaneWingDelete.json
+++ b/modManifests/ChicaneWingDelete.json
@@ -21,12 +21,12 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "ChicaneWingDelete-0.9.3.zip",
-      "version": "0.9.3",
+      "fileName": "ChicaneWingDelete-1.2.4.zip",
+      "version": "1.2.4",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/Rendresen/ChicaneWingDelete/releases/download/v0.9.3/ChicaneWingDelete-0.9.3.zip",
+      "downloadUrl": "https://github.com/Rendresen/ChicaneWingDelete/releases/download/v1.2.4/ChicaneWingDelete-1.2.4.zip",
       "hash": null
     }
   ]


### PR DESCRIPTION
Adds NOMNOM manifest for ChicaneWingDelete.

Release:
https://github.com/Rendresen/ChicaneWingDelete/releases/tag/v0.9.3

Asset:
https://github.com/Rendresen/ChicaneWingDelete/releases/download/v0.9.3/ChicaneWingDelete-0.9.3.zip

Notes:
- BepInEx 5 plugin.
- Release zip contains only ChicaneWingDelete.dll.
- GitHub auto-update metadata is included.