### PR TITLE
Add F16VaporTuner

### DIFF
--- a/modManifests/F16VaporTuner.json
+++ b/modManifests/F16VaporTuner.json
@@ -1,0 +1,43 @@
+{
+  "id": "F16VaporTuner",
+  "displayName": "F-16 Vapor Tuner",
+  "description": "Values-only BepInEx companion plugin for Aryx’s F-16M / King Viper. Tunes wing, LERX, wingtip, and transonic vapor effects for smoother AoA vapor onset, better wingtip vortex placement/persistence, and improved transonic cone timing/density.",
+  "tags": [
+    "QoL",
+    "Aircraft",
+    "Visual"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/rendresen/F16VaporTuner"
+    }
+  ],
+  "authors": [
+    "rendresen"
+  ],
+  "githubOwner": "rendresen",
+  "githubRepoName": "F16VaporTuner",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "F16VaporTuner-1.0.0.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/rendresen/F16VaporTuner/releases/download/v1.0.0/F16VaporTuner-1.0.0.zip",
+      "hash": "sha256:a39332086e47c64c294805f2847d285e0149273477268e0ed115ee8d07bc3f13",
+      "dependencies": [
+        {
+          "id": "aryx.f16m",
+          "version": "1.1.1"
+        },
+        {
+          "id": "com.nikkorap.blueprinter",
+          "version": "1.8.17"
+        }
+      ]
+    }
+  ]
+}

--- a/modManifests/F16VaporTuner.json
+++ b/modManifests/F16VaporTuner.json
@@ -1,7 +1,7 @@
 {
   "id": "F16VaporTuner",
   "displayName": "F-16 Vapor Tuner",
-  "description": "Values-only BepInEx companion plugin for Aryx’s F-16M / King Viper. Tunes wing, LERX, wingtip, and transonic vapor effects for smoother AoA vapor onset, better wingtip vortex placement/persistence, and improved transonic cone timing/density.",
+  "description": "BepInEx companion plugin for Aryx's F-16M / King Viper. Tunes wing, LERX, wingtip, and transonic vapor effects for smoother AoA vapor onset, better wingtip vortex placement, and improved transonic cone behavior.",
   "tags": [
     "QoL",
     "Aircraft",
@@ -10,24 +10,24 @@
   "urls": [
     {
       "name": "info",
-      "url": "https://github.com/rendresen/F16VaporTuner"
+      "url": "https://github.com/Rendresen/F16VaporTuner"
     }
   ],
   "authors": [
-    "rendresen"
+    "Rendresen"
   ],
-  "githubOwner": "rendresen",
+  "githubOwner": "Rendresen",
   "githubRepoName": "F16VaporTuner",
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "F16VaporTuner-1.0.0.zip",
-      "version": "1.0.0",
+      "fileName": "F16VaporTuner-1.1.10.zip",
+      "version": "1.1.10",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/rendresen/F16VaporTuner/releases/download/v1.0.0/F16VaporTuner-1.0.0.zip",
-      "hash": "sha256:a39332086e47c64c294805f2847d285e0149273477268e0ed115ee8d07bc3f13",
+      "downloadUrl": "https://github.com/Rendresen/F16VaporTuner/releases/download/v1.1.10/F16VaporTuner-1.1.10.zip",
+      "hash": "sha256:PASTE_RELEASE_ZIP_SHA256_HERE",
       "dependencies": [
         {
           "id": "aryx.f16m",


### PR DESCRIPTION
Adds F16VaporTuner, a BepInEx companion plugin for Aryx's F-16M that tunes wing, LERX, wingtip, and transonic vapor effects.

Release asset contains only F16VaporTuner.dll.

Changes
Tunes wing, LERX, wingtip, and transonic vapor effects to more subtle but still present effects.
Smooths AoA vapor onset.
Improves wingtip vortex placement and persistence.
Improves transonic cone timing and density while keeping the game’s stock altitude-aware transonic logic.

Tested as a values-only patch:
- no Update method
- no per-frame checks
- no runtime clamp
- no runtime particle clearing
- no recurring scan loop
- no diagnostic file generation