### PR TITLE
Add RITA_RVWS

### DIFF
--- a/modManifests/RITA_RVWS.json
+++ b/modManifests/RITA_RVWS.json
@@ -22,10 +22,17 @@
 		{
 			"type": "plugin",
 			"fileName": "RITA_RVWS",
-			"downloadUrl": "https://github.com/muhimin01/no-rita-rvws/releases/download/2.0.0/RITA_RVWS_2.0.0.zip",
+			"downloadUrl": "https://github.com/muhimin01/no-rita-rvws/releases/download/2.0.1/RITA_RVWS_2.0.1.zip",
 			"gameVersion": "0.33",
-			"version": "2.0.0",
-			"category": "release"
+			"version": "2.0.1",
+			"category": "release",
+			"incompatibilities":
+			[
+				{
+					"id": "com.JUSTJ7780.globalsoundreplacerno",
+					"version": "5.2.0"
+				}
+			]
 		}
 	]
 }

--- a/modManifests/RITA_RVWS.json
+++ b/modManifests/RITA_RVWS.json
@@ -25,13 +25,7 @@
 			"downloadUrl": "https://github.com/muhimin01/no-rita-rvws/releases/download/2.0.0/RITA_RVWS_2.0.0.zip",
 			"gameVersion": "0.33",
 			"version": "2.0.0",
-			"category": "release",
-			"incompatibilities": [
-				{
-					"id": "WSOYappinator",
-					"version": "2.1.1"
-				}
-			]
+			"category": "release"
 		}
 	]
 }

--- a/modManifests/RITA_RVWS.json
+++ b/modManifests/RITA_RVWS.json
@@ -1,0 +1,37 @@
+{
+	"id": "RITA_RVWS",
+	"displayName": "RITA: Russian Voice Warning System",
+	"description": "Replaces Nuclear Option's English Voice Warning System with Russian equivalents.",
+	"tags": [
+		"Flavour",
+		"Sound"
+	],
+	"urls": [
+		{
+			"name": "info",
+			"url": "https://github.com/muhimin01/no-rita-rvws"
+		}
+	],
+	"authors": [
+		"betanonymous"
+	],
+	"githubOwner": "muhimin01",
+	"githubRepoName": "no-rita-rvws",
+	"autoUpdateArtifacts": "True",
+	"artifacts": [
+		{
+			"type": "plugin",
+			"fileName": "RITA_RVWS",
+			"downloadUrl": "https://github.com/muhimin01/no-rita-rvws/releases/download/2.0.0/RITA_RVWS_2.0.0.zip",
+			"gameVersion": "0.33",
+			"version": "2.0.0",
+			"category": "release",
+			"incompatibilities": [
+				{
+					"id": "WSOYappinator",
+					"version": "2.1.1"
+				}
+			]
+		}
+	]
+}

--- a/modManifests/RITA_RVWS.json
+++ b/modManifests/RITA_RVWS.json
@@ -25,14 +25,7 @@
 			"downloadUrl": "https://github.com/muhimin01/no-rita-rvws/releases/download/2.0.1/RITA_RVWS_2.0.1.zip",
 			"gameVersion": "0.33",
 			"version": "2.0.1",
-			"category": "release",
-			"incompatibilities":
-			[
-				{
-					"id": "com.JUSTJ7780.globalsoundreplacerno",
-					"version": "5.2.0"
-				}
-			]
+			"category": "release"
 		}
 	]
 }


### PR DESCRIPTION
# RITA: Nuclear Option Russian Voice Warning System

A Nuclear Option mod that replaces the English Voice Warning System with Russian equivalents.

## Mod version: 2.0.1 | Nuclear Option version: 0.33.x
- Link to mod: https://github.com/muhimin01/no-rita-rvws


## BepInEx Configuration Manager compatible
- Option to disable/enable RITA globally
- Option to disable/enable RITA based on current player faction