### PR TITLE
Add Shoshanas Strategic Strike Console

### DIFF
--- a/modManifests/emi.shoshanas.ballisticstrikecaller.json
+++ b/modManifests/emi.shoshanas.ballisticstrikecaller.json
@@ -1,0 +1,32 @@
+{
+  "id": "emi.shoshanas.ballisticstrikecaller",
+  "displayName": "Shoshanas Strategic Strike Console",
+  "description": "Shoshanas Balliistic Strike console is a Mod where you can launch a type of payloads as hypersonic or custom MT Nukes with a fee.",
+  "tags": [
+    "QoL",
+    "Utility"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/NotAnomie/Nomnom-Mod-Releases/releases/tag/v1.6.11"
+    }
+  ],
+  "authors": [
+    "Anomie"
+  ],
+  "githubOwner": "NotAnomie",
+  "githubRepoName": "NOMNOM-emi-shoshanas-ballisticstrikecaller",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "type": "plugin",
+      "fileName": "emi.shoshanas.ballisticstrikecaller_v2.1.7.zip",
+      "downloadUrl": "https://github.com/NotAnomie/NOMNOM-emi-shoshanas-ballisticstrikecaller/releases/download/v2.1.7/emi.shoshanas.ballisticstrikecaller_v2.1.7.zip",
+      "hash": "sha256:b748fb7d8dd805013a274d9b50d144fd4f553cf952246ae764d165dd742874d7",
+      "gameVersion": "0.33",
+      "version": "2.1.7",
+      "category": "Release"
+    }
+  ]
+}


### PR DESCRIPTION
Adds NOMNOM manifest for `emi.shoshanas.ballisticstrikecaller` version `2.1.7`.

Created with Anomie UI NOMNOM Publisher.