### PR TITLE
Add ChimeraTailWeld manifest

### DIFF
--- a/modManifests/ChimeraTailWeld.json
+++ b/modManifests/ChimeraTailWeld.json
@@ -1,0 +1,24 @@
+{
+  "id": "ChimeraTailWeld",
+  "displayName": "Chimera Tail Weld",
+  "description": "Welds the Aryx MC-260 Chimera's Fuselage_Top_Rear panel into the airframe so the V-tail no longer visibly twists the rear fuselage. Single-piece weld via the game's own AeroPart.MergeWithParent; vanilla flight model preserved.",
+  "tags": ["mod", "Aircraft", "QoL"],
+  "urls": [
+    { "name": "info", "url": "https://github.com/Rendresen/ChimeraTailWeld" }
+  ],
+  "authors": ["Rendresen"],
+  "githubOwner": "Rendresen",
+  "githubRepoName": "ChimeraTailWeld",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "ChimeraTailWeld-v1.0.0.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/Rendresen/ChimeraTailWeld/releases/download/v1.0.0/ChimeraTailWeld-v1.0.0.zip",
+      "hash": "sha256:08b7cd5ce9a8688de7c3acc4832288a03f4f654de405aadf204283fb03ef75b1"
+    }
+  ]
+}


### PR DESCRIPTION
First-listing manifest for **ChimeraTailWeld** (Rendresen).

Repo: https://github.com/Rendresen/ChimeraTailWeld
Release: https://github.com/Rendresen/ChimeraTailWeld/releases/tag/v1.0.0
Manifest on fork: https://github.com/Rendresen/NOMNOM/blob/main/modManifests/ChimeraTailWeld.json

BepInEx plugin for Nuclear Option that welds the Aryx MC-260 Chimera's `Fuselage_Top_Rear` panel into the airframe so the V-tail aero load no longer visibly twists the rear fuselage at speed. Single-piece weld via the game's own `AeroPart.MergeWithParent` + per-aircraft mass / CoM / inertia tensor reconciliation + an impact-breaker MonoBehaviour so the welded part still tears off on a hard crash. Vanilla flight model preserved (only the one twisting panel is welded; control surfaces and all aero-active V-tail parts keep their own rigidbody + joint chain).

`autoUpdateArtifacts: "True"` so future version bumps land in NOMNOM automatically.

Local sha256 of the v1.0.0 release zip is `08b7cd5ce9a8688de7c3acc4832288a03f4f654de405aadf204283fb03ef75b1` - embedded in the manifest.