### PR TITLE
Add Equalizer Mod

### DIFF
--- a/modManifests/com.equalizer.unified.json
+++ b/modManifests/com.equalizer.unified.json
@@ -16,7 +16,7 @@
     "Neutral Observer"
   ],
   "githubOwner": "SonPamungkas",
-  "githubRepoName": "NOMNOM-com-equalizer-unified",
+  "githubRepoName": "equalizer-mod",
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {

--- a/modManifests/com.equalizer.unified.json
+++ b/modManifests/com.equalizer.unified.json
@@ -9,7 +9,7 @@
   "urls": [
     {
       "name": "info",
-      "url": "https://github.com/SonPamungkas/NOMNOM-com-equalizer-unified"
+      "url": "https://github.com/SonPamungkas/equalizer-mod"
     }
   ],
   "authors": [

--- a/modManifests/com.equalizer.unified.json
+++ b/modManifests/com.equalizer.unified.json
@@ -1,0 +1,32 @@
+{
+  "id": "com.equalizer.unified",
+  "displayName": "Equalizer Mod",
+  "description": "Equalize modded airframes and ground units with vanilla in Inventory and Factory (Production)",
+  "tags": [
+    "QoL",
+    "Utility"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/SonPamungkas/NOMNOM-com-equalizer-aircraft-v2"
+    }
+  ],
+  "authors": [
+    "Neutral Observer"
+  ],
+  "githubOwner": "SonPamungkas",
+  "githubRepoName": "NOMNOM-com-equalizer-unified",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "type": "plugin",
+      "fileName": "com.equalizer.unified_v2.2.0.zip",
+      "downloadUrl": "https://github.com/SonPamungkas/NOMNOM-com-equalizer-unified/releases/download/v2.2.0/com.equalizer.unified_v2.2.0.zip",
+      "hash": "sha256:ebce7d893a42294524b862e633e392b52246e9ba81424c13b44c0842090446a8",
+      "gameVersion": "0.33.3",
+      "version": "2.2.0",
+      "category": "Release"
+    }
+  ]
+}

--- a/modManifests/com.equalizer.unified.json
+++ b/modManifests/com.equalizer.unified.json
@@ -9,7 +9,7 @@
   "urls": [
     {
       "name": "info",
-      "url": "https://github.com/SonPamungkas/NOMNOM-com-equalizer-aircraft-v2"
+      "url": "https://github.com/SonPamungkas/NOMNOM-com-equalizer-unified"
     }
   ],
   "authors": [


### PR DESCRIPTION
Adds NOMNOM manifest for `com.equalizer.unified` version `2.2.0`.

Created with Anomie UI NOMNOM Publisher.