### PR TITLE
Add Horus Mod Starter manifest

### DIFF
--- a/modManifests/HorusMod.json
+++ b/modManifests/HorusMod.json
@@ -1,0 +1,39 @@
+{
+  "id": "HorusMod",
+  "displayName": "Horus Mod Starter",
+  "description": "A Game Master / free camera utility mod for Nuclear Option that lets the host or local player spawn aircraft, vehicles, ships, buildings, and scenery in real time.",
+  "tags": [
+    "QoL",
+    "Utility",
+    "Sandbox",
+    "Server",
+    "Camera"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/ReapeRAlan/Horus-Mod"
+    },
+    {
+      "name": "steamGuide",
+      "url": "https://steamcommunity.com/sharedfiles/filedetails/?id=3738218049"
+    }
+  ],
+  "authors": [
+    "ReapeRAlan"
+  ],
+  "githubOwner": "ReapeRAlan",
+  "githubRepoName": "Horus-Mod",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "type": "plugin",
+      "fileName": "Horus_Mod_Starter_v1.0.9.zip",
+      "downloadUrl": "https://github.com/ReapeRAlan/Horus-Mod/releases/download/v1.0.9/Horus_Mod_Starter_v1.0.9.zip",
+      "gameVersion": "0.33.3",
+      "version": "1.0.9",
+      "category": "Release",
+      "hash": "sha256:f6414b84d1df84c691cdb80fa9db75cce592e066d66fe807e9e379f36449c5fe"
+    }
+  ]
+}


### PR DESCRIPTION
Adds Horus Mod Starter to NOMNOM.

Horus Mod Starter is a BepInEx 5 plugin for Nuclear Option that provides a free camera / Game Master-style tool for spawning aircraft, vehicles, ships, buildings, and scenery in real time.

GitHub release:
https://github.com/ReapeRAlan/Horus-Mod/releases/tag/v1.0.9

Steam guide:
https://steamcommunity.com/sharedfiles/filedetails/?id=3738218049

Release asset:
https://github.com/ReapeRAlan/Horus-Mod/releases/download/v1.0.9/Horus_Mod_Starter_v1.0.9.zip

SHA256:
sha256:f6414b84d1df84c691cdb80fa9db75cce592e066d66fe807e9e379f36449c5fe