### PR TITLE
Fix description of mod

### DIFF
--- a/modManifests/Com.Hellcat92.FuelBurnEnduranceTimer.json
+++ b/modManifests/Com.Hellcat92.FuelBurnEnduranceTimer.json
@@ -1,7 +1,7 @@
 {
   "id": "Com.Hellcat92.FuelBurnEnduranceTimer",
   "displayName": "NO-FuelBurnEnduranceTimer",
-  "description": "QoL mod to toggle player names on and off and change icon colours in HUD and MAP.",
+  "description": "Shows you how much time you have until the engines flame out from fuel starvation, accounting to your current throttle level, and quantity of fuel onboard. Calculates fuel burn rate and displays an endurance timer with said values. Updates every second.",
   "tags": [
     "mod",
     "QoL",


### PR DESCRIPTION
Apparently I copypasted the wrong description on the initial commit. At the author's request, this fixes that.