### PR TITLE
Update Anomie Kestrel Warhead Payload Patch relations

### DIFF
--- a/modManifests/anomie.kestrel.warheadpayloadpatch.json
+++ b/modManifests/anomie.kestrel.warheadpayloadpatch.json
@@ -34,6 +34,10 @@
         {
           "id": "com.nikkorap.blueprinter",
           "version": "1.8.19"
+        },
+        {
+          "id": "QoL",
+          "version": "1.7.1.0"
         }
       ]
     },


### PR DESCRIPTION
Updates only dependency, incompatibility and extends fields for `anomie.kestrel.warheadpayloadpatch`.

All artifacts, download counts and unrelated manifest fields are preserved from the latest upstream manifest.