### PR TITLE
Add WT Mouse Aim mod manifest

### DIFF
--- a/modManifests/NuclearOption-MouseAim.json
+++ b/modManifests/NuclearOption-MouseAim.json
@@ -1,0 +1,39 @@
+{
+  "id": "NuclearOption-MouseAim",
+  "displayName": "WT Mouse Aim",
+  "description": "War Thunder-style point-and-chase mouse aim for Nuclear Option. The mouse moves a world-locked aim marker; a thin instructor rolls the aircraft's lift vector onto it then pulls up into it, and levels out as the nose arrives. The game's own fly-by-wire still governs the envelope. Includes cockpit and third-person camera follow, per-axis manual stick override, RMB free-look, a Fly Level autopilot toggle, and 50+ live-tunable parameters (F1 via BepInEx ConfigurationManager).",
+  "tags": [
+    "flight control",
+    "mouse",
+    "QoL"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/cosistra/wt-mouse-aim"
+    }
+  ],
+  "authors": [
+    "cosistra"
+  ],
+  "githubOwner": "cosistra",
+  "githubRepoName": "wt-mouse-aim",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "NuclearOption-MouseAim.dll",
+      "version": "0.27.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/cosistra/wt-mouse-aim/releases/download/v0.27.0/NuclearOption-MouseAim.dll",
+      "hash": "sha256:2f87ac3f2c19d4766136c6489f13ae43cc922246023c07cb43962fbec4528c74",
+      "dependencies": [
+        {
+          "id": "BepInEx.ConfigurationManager",
+          "version": "18.4.1"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a manifest for **WT Mouse Aim** — a War Thunder–style point-and-chase mouse-aim mod for Nuclear Option (BepInEx 5 / HarmonyX plugin).

- **Repo:** https://github.com/cosistra/wt-mouse-aim
- **Release:** https://github.com/cosistra/wt-mouse-aim/releases/tag/v0.27.0
- **id / file:** `NuclearOption-MouseAim` (matches the DLL AssemblyName and the JSON filename)
- **Game version:** 0.33
- **Type:** plugin · **Dependency:** BepInEx.ConfigurationManager 18.4.1 (for live F1 tuning)
- `autoUpdateArtifacts` is `True`; the repo follows the conventions (one mod per repo, one asset per release, `vX.Y.Z` tags) so future releases can be auto-ingested.

The single release asset is the bare `NuclearOption-MouseAim.dll`, and the manifest `hash` is the SHA-256 of that asset. Schema-validated locally against `ValidationSchema.json`.