### PR TITLE
Add Infinite Ammo mod manifest

### DIFF
--- a/modManifests/NuclearOption-InfiniteAmmo.json
+++ b/modManifests/NuclearOption-InfiniteAmmo.json
@@ -1,0 +1,34 @@
+{
+  "id": "NuclearOption-InfiniteAmmo",
+  "displayName": "Infinite Ammo",
+  "description": "Rearms ALL weapon stations (including linked guns and AI-gunner stations) and ALL countermeasure dispensers when empty, and refuels at low fuel. SINGLEPLAYER ONLY - rearm/refuel writes are server-authoritative and ignored on real multiplayer servers.",
+  "tags": [
+    "cheat",
+    "singleplayer",
+    "QoL"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/cosistra/nuclear-option-infinite-ammo"
+    }
+  ],
+  "authors": [
+    "cosistra",
+    "DaBlackPantha"
+  ],
+  "githubOwner": "cosistra",
+  "githubRepoName": "nuclear-option-infinite-ammo",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "NuclearOption-InfiniteAmmo.dll",
+      "version": "1.1.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/cosistra/nuclear-option-infinite-ammo/releases/download/v1.1.0/NuclearOption-InfiniteAmmo.dll",
+      "hash": "sha256:2408fe71dbf38ec325cc22feec1a75b59849bd29933a4e6131df62273f4a950e"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a manifest for **Infinite Ammo**, a BepInEx 5 mod for Nuclear Option.

- **Repo:** https://github.com/cosistra/nuclear-option-infinite-ammo
- **Release:** https://github.com/cosistra/nuclear-option-infinite-ammo/releases/tag/v1.1.0
- **File added:** `modManifests/NuclearOption-InfiniteAmmo.json`

**What it does:** rearms all weapon stations (including linked guns and AI-gunner stations) and all countermeasure dispensers when empty, and refuels at low fuel.

**Note:** Singleplayer only — rearm/refuel are server-authoritative and ignored on real multiplayer servers; this is stated loudly in the description, README, load log, and config. `autoUpdateArtifacts` is enabled so future releases are picked up automatically. No dependencies. A faithful BepInEx port of DaBlackPantha's original MelonLoader mod (credited).