### PR TITLE
Update hash for com.basicGrowl version 1.0.1

### DIFF
--- a/manifest/manifest.json
+++ b/manifest/manifest.json
@@ -2385,7 +2385,7 @@
         "gameVersion": "0.33.4",
         "version": "1.0.1",
         "category": "release",
-        "hash": "sha256:3064c0982f6d708111c6d7561a9374a3dc91a77b2924a94a9ef16eb9f9d3a107"
+        "hash": "sha256:5c06aab1df2aaf6c72e610c2df599070b7d875a52f4eac53b43c6e14280e3dea"
       },
       {
         "type": "plugin",

--- a/modManifests/com.basicGrowl.json
+++ b/modManifests/com.basicGrowl.json
@@ -32,7 +32,7 @@
       "gameVersion": "0.33.4",
       "version": "1.0.1",
       "category": "release",
-      "hash": "sha256:3064c0982f6d708111c6d7561a9374a3dc91a77b2924a94a9ef16eb9f9d3a107"
+      "hash": "sha256:5c06aab1df2aaf6c72e610c2df599070b7d875a52f4eac53b43c6e14280e3dea"
     },
     {
       "type": "plugin",


### PR DESCRIPTION
Corrected previous hash to new hash, due to retroactive changes applied to both 1.0.0 and 1.0.1.