### PR TITLE
Add Nuclear Option eXternal MFD (NOXMFD)

### DIFF
--- a/modManifests/NOXMFD.json
+++ b/modManifests/NOXMFD.json
@@ -25,7 +25,7 @@
       "category": "preRelease",
       "type": "plugin",
       "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/roke77/NOXMFD/releases/download/v0.9.0/NOXMFD_0.9.0.zip",
+      "downloadUrl": "https://github.com/roke77/NOXMFD/releases/download/0.9.0/NOXMFD_0.9.0.zip",
       "hash": "sha256:dd5dc88fb3312e01872ffdd3a0b426506e3cc745417d6049283e0c2f041b84ac"
     }
   ]

--- a/modManifests/NOXMFD.json
+++ b/modManifests/NOXMFD.json
@@ -1,0 +1,32 @@
+{
+  "id": "NOXMFD",
+  "displayName": "Nuclear Option eXternal MFD",
+  "description": "Reads live flight telemetry and serves a browser-based multi-function display (MFD) over the local network.",
+  "tags": [
+    "mod",
+    "QoL"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/roke77/NOXMFD"
+    }
+  ],
+  "authors": [
+    "roke77"
+  ],
+  "githubOwner": "roke77",
+  "githubRepoName": "NOXMFD",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "NOXMFD_0.9.0.zip",
+      "version": "0.9.0",
+      "category": "preRelease",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/roke77/NOXMFD/releases/download/v0.9.0/NOXMFD_0.9.0.zip",
+      "hash": "sha256:dd5dc88fb3312e01872ffdd3a0b426506e3cc745417d6049283e0c2f041b84ac"
+    }
+  ]
+}


### PR DESCRIPTION
Registers **NOXMFD v0.9.0** (alpha pre-release) — a BepInEx 5 plugin that reads live flight telemetry from Nuclear Option and serves a browser-based multi-function display (MFD) over the local network.

- Single-mod repo: https://github.com/roke77/NOXMFD
- One zip asset per release; `autoUpdateArtifacts` enabled
- No required dependencies (ConfigurationManager is optional)
- Release: https://github.com/roke77/NOXMFD/releases/tag/0.9.0