### PR TITLE
Add manifests for UndelayedThrottle and TarantulaTiltSensitivity

### DIFF
--- a/modManifests/TarantulaTiltSensitivity.json
+++ b/modManifests/TarantulaTiltSensitivity.json
@@ -1,0 +1,32 @@
+{
+  "id": "TarantulaTiltSensitivity",
+  "displayName": "Tarantula Tilt Sensitivity",
+  "description": "Adds a fine-control sensitivity curve to the Tarantula's manual rotor tilt near 0 degrees, so small adjustments around level flight are precise instead of twitchy.",
+  "tags": [
+    "QoL",
+    "Aircraft"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/lucaspevidor/nuclear-option-tarantula-tilt-sensitivity"
+    }
+  ],
+  "authors": [
+    "Lucas Pevidor"
+  ],
+  "githubOwner": "lucaspevidor",
+  "githubRepoName": "nuclear-option-tarantula-tilt-sensitivity",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "TarantulaTiltSensitivity.dll",
+      "version": "1.0.2",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/lucaspevidor/nuclear-option-tarantula-tilt-sensitivity/releases/download/v1.0.2/TarantulaTiltSensitivity.dll",
+      "hash": "sha256:b1fb596a4a883aa1bfdb616bed0210c9c3c44d4d771601db5120e0c600010051"
+    }
+  ]
+}

--- a/modManifests/UndelayedThrottle.json
+++ b/modManifests/UndelayedThrottle.json
@@ -1,0 +1,31 @@
+{
+  "id": "UndelayedThrottle",
+  "displayName": "Undelayed Throttle",
+  "description": "Removes the hidden negative-throttle dead zone so incremental (gamepad / relative-axis) throttle responds immediately when raising thrust up from idle.",
+  "tags": [
+    "QoL"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/lucaspevidor/nuclear-option-undelayed-throttle"
+    }
+  ],
+  "authors": [
+    "Lucas Pevidor"
+  ],
+  "githubOwner": "lucaspevidor",
+  "githubRepoName": "nuclear-option-undelayed-throttle",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "UndelayedThrottle.dll",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/lucaspevidor/nuclear-option-undelayed-throttle/releases/download/v1.0.0/UndelayedThrottle.dll",
+      "hash": "sha256:17002fd05e3fb01ee703f32d85656e2c06cf63977aa9bf81361ca70d67fa5710"
+    }
+  ]
+}


### PR DESCRIPTION
Two BepInEx plugin mods by Lucas Pevidor:
- UndelayedThrottle (v1.0.0): removes the hidden negative-throttle dead zone for incremental gamepad/relative-axis throttle.
- TarantulaTiltSensitivity (v1.0.2): fine-control sensitivity curve for the Tarantula's manual rotor tilt near level.

Both point at published GitHub releases with sha256 hashes and auto-update enabled.