### PR TITLE
Add Radar Missile Control

### DIFF
--- a/modManifests/blacknight2u.sarhcontrol.json
+++ b/modManifests/blacknight2u.sarhcontrol.json
@@ -1,0 +1,38 @@
+{
+  "id": "blacknight2u.sarhcontrol",
+  "displayName": "Radar Missile Control",
+  "description": "Host-controlled radar missile difficulty mod. Affects only AI-launched SARH and ARH missiles targeting human pilots; player weapons remain vanilla. Press F8 as host to cycle OFF (VANILLA), NERFED (50%), and DISABLED. Status text appears only when toggled.",
+  "tags": [
+    "gameplay",
+    "difficulty",
+    "sarh",
+    "arh",
+    "host-only",
+    "multiplayer"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/blacknight2u/NuclearOption-RadarMissileControl"
+    }
+  ],
+  "authors": [
+    "blacknight2u"
+  ],
+  "githubOwner": "blacknight2u",
+  "githubRepoName": "NuclearOption-RadarMissileControl",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "SARHControl-v0.4.1.zip",
+      "version": "0.4.1",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33.4",
+      "downloadUrl": "https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/download/v0.4.1/SARHControl-v0.4.1.zip",
+      "hash": "sha256:8f43cb60058a2a67d52d7086437ec4e8bacfa84c81dc7c7e28a91ec4bb11e754",
+      "dependencies": [],
+      "incompatibilities": []
+    }
+  ]
+}

--- a/modManifests/blacknight2u.sarhcontrol.json
+++ b/modManifests/blacknight2u.sarhcontrol.json
@@ -1,12 +1,13 @@
 {
   "id": "blacknight2u.sarhcontrol",
   "displayName": "Radar Missile Control",
-  "description": "Host-controlled radar missile difficulty mod. Affects only AI-launched SARH and ARH missiles targeting human pilots; player weapons remain vanilla. Press F8 as host to cycle OFF (VANILLA), NERFED (50%), and DISABLED. Status text appears only when toggled.",
+  "description": "Host-configurable radar missile rules for SARH and ARH weapons. Press F7 to choose player/AI launch-target routes and adjust guidance, accuracy, thrust, and speed; F8 cycles OFF (VANILLA), NERFED, and DISABLED. Gameplay remains host-authoritative.",
   "tags": [
     "gameplay",
     "difficulty",
     "sarh",
     "arh",
+    "configurable",
     "host-only",
     "multiplayer"
   ],
@@ -24,13 +25,13 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "SARHControl-v0.4.1.zip",
-      "version": "0.4.1",
+      "fileName": "SARHControl-v0.5.0.zip",
+      "version": "0.5.0",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.33.4",
-      "downloadUrl": "https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/download/v0.4.1/SARHControl-v0.4.1.zip",
-      "hash": "sha256:8f43cb60058a2a67d52d7086437ec4e8bacfa84c81dc7c7e28a91ec4bb11e754",
+      "gameVersion": "0.34.1",
+      "downloadUrl": "https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/download/v0.5.0/SARHControl-v0.5.0.zip",
+      "hash": "sha256:f7c7aa9a0d83c92cadcdf53a80fc171372662070f086e14a9cb855c982c725ba",
       "dependencies": [],
       "incompatibilities": []
     }


### PR DESCRIPTION
## Summary

Registers **Radar Missile Control** (`blacknight2u.sarhcontrol`) in NOMNOM with stable release `v0.5.0`, tested on Nuclear Option `0.34.1`.

## What the mod does

- Gives the authoritative host an `F7` settings panel and an `F8` mode cycle: **OFF (VANILLA) → NERFED → DISABLED**.
- Independently selects SARH and ARH missiles.
- Configures AI/player launcher-to-target engagement routes; the safe default remains AI → Player only.
- Adjusts tracking, lock persistence, jam tolerance, thrust, top speed, and moving aim error without changing warhead damage.
- Synchronizes host-controlled status/settings to modded clients while keeping gameplay authority on the host/server.

## Source and release

- Open source: https://github.com/blacknight2u/NuclearOption-RadarMissileControl
- Release: https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/tag/v0.5.0
- Source commit: `d6c3bcbdfde5d2b37e58e552aa2c7f2ea776a9e6`
- Asset: `SARHControl-v0.5.0.zip`
- SHA-256: `f7c7aa9a0d83c92cadcdf53a80fc171372662070f086e14a9cb855c982c725ba`
- Game version: `0.34.1`
- BepInEx: `5`

## Validation

- `Validate-JsonSchema.ps1`: passed
- `Validate-JsonContent.ps1`: passed
- Release build: succeeded with 0 warnings and 0 errors against the installed 0.34.1 assemblies
- Packaged DLL version: `0.5.0.0`
- Packaged DLL embeds the public source commit revision
- Packaged logic matches the locally tested v0.5.0 build
- GitHub release asset digest matches the manifest hash