### PR TITLE
Add Loyal Wingman

### DIFF
--- a/modManifests/LoyalWingman.json
+++ b/modManifests/LoyalWingman.json
@@ -1,7 +1,7 @@
 {
   "id": "LoyalWingman",
   "displayName": "Loyal Wingman",
-  "description": "Initial stable release of the Loyal Wingman plugin.",
+  "description": "Nuclear Option 0.34 compatibility prerelease of the Loyal Wingman plugin.",
   "authors": [
     "Loyal Wingman contributors"
   ],
@@ -17,12 +17,12 @@
   "artifacts": [
     {
       "fileName": "LoyalWingman.dll",
-      "version": "0.0.1",
-      "category": "release",
+      "version": "0.0.2",
+      "category": "preRelease",
       "type": "plugin",
-      "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/NOLoyalWingman/LoyalWingman/releases/download/v0.0.1/LoyalWingman.dll",
-      "hash": "sha256:30046e29496df9d37b6d396c908bdd862c107dbab34c4aeb5f6c6c619af47363",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/NOLoyalWingman/LoyalWingman/releases/download/v0.0.2/LoyalWingman.dll",
+      "hash": "sha256:91c9eefa32fe784a9adc852c27ba8c525f3dcd9d611d669aaa0070d88c4c5c6f",
       "dependencies": [
         {
           "id": "com.nikkorap.blueprinter",

--- a/modManifests/LoyalWingman.json
+++ b/modManifests/LoyalWingman.json
@@ -1,0 +1,38 @@
+{
+  "id": "LoyalWingman",
+  "displayName": "Loyal Wingman",
+  "description": "Initial stable release of the Loyal Wingman plugin.",
+  "authors": [
+    "Loyal Wingman contributors"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/NOLoyalWingman/LoyalWingman"
+    }
+  ],
+  "githubOwner": "NOLoyalWingman",
+  "githubRepoName": "LoyalWingman",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "LoyalWingman.dll",
+      "version": "0.0.1",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/NOLoyalWingman/LoyalWingman/releases/download/v0.0.1/LoyalWingman.dll",
+      "hash": "sha256:30046e29496df9d37b6d396c908bdd862c107dbab34c4aeb5f6c6c619af47363",
+      "dependencies": [
+        {
+          "id": "com.nikkorap.blueprinter",
+          "version": "1.8.21"
+        },
+        {
+          "id": "blueprinter.kestrel",
+          "version": "2.2.0"
+        }
+      ]
+    }
+  ]
+}

--- a/modManifests/LoyalWingman.json
+++ b/modManifests/LoyalWingman.json
@@ -22,7 +22,7 @@
       "type": "plugin",
       "gameVersion": "0.34",
       "downloadUrl": "https://github.com/NOLoyalWingman/LoyalWingman/releases/download/v0.0.2/LoyalWingman.dll",
-      "hash": "sha256:91c9eefa32fe784a9adc852c27ba8c525f3dcd9d611d669aaa0070d88c4c5c6f",
+      "hash": "sha256:d4ff9f70ee2c73433f094a0a8733fc48865dd5b94ba82d00bb795b35d3f56d54",
       "dependencies": [
         {
           "id": "com.nikkorap.blueprinter",


### PR DESCRIPTION
## Summary

- add the stable Loyal Wingman 0.0.1 plugin manifest
- declare Blueprinter 1.8.21 and FQ-106/Kestrel 2.2.0 dependencies
- point NOMNOM to the public source repository and verified GitHub Release DLL digest

## Validation

- `Validate-JsonSchema.ps1`: passed
- `Validate-JsonContent.ps1`: passed
- release asset URL and SHA-256 digest: verified
- source is public, MIT-licensed, and the DLL is unobfuscated