### PR TITLE
Add ChaseView

### DIFF
--- a/modManifests/ChaseView.json
+++ b/modManifests/ChaseView.json
@@ -1,0 +1,33 @@
+{
+  "id": "ChaseView",
+  "displayName": "ChaseView",
+  "description": "Chase style camera, complete with HUD, optional weapon select flavor graphics (and damage model); works with (probably) every aircraft.",
+  "tags": [
+    "mod",
+    "QoL",
+    "HUD"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/Oliepolie/ChaseView/blob/main/README.md"
+    }
+  ],
+  "authors": [
+    "Oliepolie"
+  ],
+  "githubOwner": "Oliepolie",
+  "githubRepoName": "ChaseView",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "ChaseView-1.0.0.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/Oliepolie/ChaseView/releases/download/v1.0.0/ChaseView-1.0.0.zip",
+      "hash": "sha256:80ffef90d5769f658c0ca5153d81d57ac0be11f17bf146948447f4afbe220a5f"
+    }
+  ]
+}

--- a/modManifests/ChaseView.json
+++ b/modManifests/ChaseView.json
@@ -1,7 +1,7 @@
 {
   "id": "ChaseView",
   "displayName": "ChaseView",
-  "description": "A proper third-person chase camera, with the HUD. Nuclear Option already has a chase camera but won't show the HUD from it, won't let head tracking look around from it, and won't let you aim a turret from it. ChaseView fixes all three, slots chase into the Switch View cycle right after the cockpit, and frames every aircraft consistently using its real dimensions. Optional Ace Combat style weapon readout and always-on damage diagram, both off by default. Needs no server-side install and works on vanilla servers. One feature (turret aiming in external views) transmits, and only the same message the game already sends from the cockpit for your own aircraft - it can be switched off if you would rather send nothing.",
+  "description": "Chase style camera, complete with HUD, optional weapon select flavor graphics (and damage display model); works with (probably) every aircraft.",
   "tags": [
     "mod",
     "QoL",

--- a/modManifests/ChaseView.json
+++ b/modManifests/ChaseView.json
@@ -1,7 +1,7 @@
 {
   "id": "ChaseView",
   "displayName": "ChaseView",
-  "description": "Chase style camera, complete with HUD, optional weapon select flavor graphics (and damage model); works with (probably) every aircraft.",
+  "description": "A proper third-person chase camera, with the HUD. Nuclear Option already has a chase camera but won't show the HUD from it, won't let head tracking look around from it, and won't let you aim a turret from it. ChaseView fixes all three, slots chase into the Switch View cycle right after the cockpit, and frames every aircraft consistently using its real dimensions. G-force blackout applies in chase exactly as it does in the cockpit, so the view costs you nothing and gains you nothing. Optional Ace Combat style weapon readout and always-on damage diagram, both off by default. Needs no server-side install and works on vanilla servers. One feature (turret aiming in external views) transmits, and only the same message the game already sends from the cockpit for your own aircraft - it can be switched off if you would rather send nothing.",
   "tags": [
     "mod",
     "QoL",
@@ -21,13 +21,13 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "ChaseView-1.0.0.zip",
-      "version": "1.0.0",
+      "fileName": "ChaseView-1.1.0.zip",
+      "version": "1.1.0",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.33",
-      "downloadUrl": "https://github.com/Oliepolie/ChaseView/releases/download/v1.0.0/ChaseView-1.0.0.zip",
-      "hash": "sha256:80ffef90d5769f658c0ca5153d81d57ac0be11f17bf146948447f4afbe220a5f"
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/Oliepolie/ChaseView/releases/download/v1.1.0/ChaseView-1.1.0.zip",
+      "hash": "sha256:aae68ea57f93cfe6046ccc954fa8ff7e35f0c364dcb541d14da24299130c8863"
     }
   ]
 }

--- a/modManifests/ChaseView.json
+++ b/modManifests/ChaseView.json
@@ -1,7 +1,7 @@
 {
   "id": "ChaseView",
   "displayName": "ChaseView",
-  "description": "A proper third-person chase camera, with the HUD. Nuclear Option already has a chase camera but won't show the HUD from it, won't let head tracking look around from it, and won't let you aim a turret from it. ChaseView fixes all three, slots chase into the Switch View cycle right after the cockpit, and frames every aircraft consistently using its real dimensions. G-force blackout applies in chase exactly as it does in the cockpit, so the view costs you nothing and gains you nothing. Optional Ace Combat style weapon readout and always-on damage diagram, both off by default. Needs no server-side install and works on vanilla servers. One feature (turret aiming in external views) transmits, and only the same message the game already sends from the cockpit for your own aircraft - it can be switched off if you would rather send nothing.",
+  "description": "A proper third-person chase camera, with the HUD. Nuclear Option already has a chase camera but won't show the HUD from it, won't let head tracking look around from it, and won't let you aim a turret from it. ChaseView fixes all three, slots chase into the Switch View cycle right after the cockpit, and frames every aircraft consistently using its real dimensions. Optional Ace Combat style weapon readout and always-on damage diagram, both off by default. Needs no server-side install and works on vanilla servers. One feature (turret aiming in external views) transmits, and only the same message the game already sends from the cockpit for your own aircraft - it can be switched off if you would rather send nothing.",
   "tags": [
     "mod",
     "QoL",


### PR DESCRIPTION
Adds ChaseView — a third-person chase camera that shows the HUD, lets TrackIR look around from external views, and fixes turret aiming outside the cockpit. 

GitHub: https://github.com/Oliepolie/ChaseView

Source is in the repo (open-source per the acceptance policy), shipped as a GitHub release asset with autoUpdateArtifacts enabled.