### PR TITLE
Infinite Ammo v1.3.0

### DIFF
--- a/modManifests/NuclearOption-InfiniteAmmo.json
+++ b/modManifests/NuclearOption-InfiniteAmmo.json
@@ -23,6 +23,15 @@
   "artifacts": [
     {
       "fileName": "NuclearOption-InfiniteAmmo.dll",
+      "version": "1.3.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/cosistra/nuclear-option-infinite-ammo/releases/download/v1.3.0/NuclearOption-InfiniteAmmo.dll",
+      "hash": "sha256:a2587d9a8b4b637e482f13ef0a4a91acfc222bc73ba7b18f1c8c12cce556d4bf"
+    },
+    {
+      "fileName": "NuclearOption-InfiniteAmmo.dll",
       "version": "1.2.0",
       "category": "release",
       "type": "plugin",


### PR DESCRIPTION
Adds Infinite Ammo v1.3.0, built and tested against Nuclear Option 0.34.

v1.3.0

Older artifacts are left at their original gameVersion on purpose - they do not work on 0.34.

Note: `run-script-windows` will report `Id NuclearOption-InfiniteAmmo is NOT UNIQUE` and go red.
That is `Validate-IdAlreadyExists` (a new-submission check) firing on a manifest update; the schema
check itself passes. Same as #210.