### PR TITLE
NuclearOption-MouseAim: add v0.68.0 (Nuclear Option 0.34 compatibility)

### DIFF
--- a/modManifests/NuclearOption-MouseAim.json
+++ b/modManifests/NuclearOption-MouseAim.json
@@ -22,6 +22,21 @@
   "artifacts": [
     {
       "fileName": "NuclearOption-MouseAim.dll",
+      "version": "0.68.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/cosistra/wt-mouse-aim/releases/download/v0.68.0/NuclearOption-MouseAim.dll",
+      "hash": "sha256:65685db9875255c32f9c6402414447ce21ef61fb4f0e8f5c925fa22b7609f5bb",
+      "dependencies": [
+        {
+          "id": "BepInEx.ConfigurationManager",
+          "version": "18.4.1"
+        }
+      ]
+    },
+    {
+      "fileName": "NuclearOption-MouseAim.dll",
       "version": "0.58.0",
       "category": "release",
       "type": "plugin",


### PR DESCRIPTION
Adds the `v0.68.0` artifact for **WT Mouse Aim** (`NuclearOption-MouseAim`). One file, one inserted artifact object, nothing else touched.

### Why this is hand-written instead of auto-updated

`hourly_update.yml` currently has its `schedule:` / `cron` block commented out, so the workflow is `workflow_dispatch`-only — the last automated `modManifests` commit was 2026-07-23. `v0.68.0` was published 2026-07-27 and wouldn't be picked up.

Heads-up either way: `Update-ModArtifact.ps1` seeds new entries with `$gameVersion = $artifacts[0].gameVersion`, so an auto-add here would have inherited `"0.33"` — the exact version this release exists to stop supporting. Not asking for a code change, just explaining the hand-written entry.

### gameVersion

`"0.34"`. This release is specifically the Nuclear Option 0.34 compatibility fix: 0.34 removed the global-namespace `Leaderboard` type, which the mod's per-frame menu-passivity guard called. Being an uncaught per-frame path, the plugin **loaded cleanly and then threw on the first in-flight tick** — it presented to users as "the mod does nothing".

Earlier artifacts are deliberately left at `"0.33"` — they genuinely do not work on 0.34.

### The entry matches what the auto-updater would have produced

- `hash` is the GitHub release asset digest (`sha256:65685db9…f5bb`)
- `fileName` / `downloadUrl` from `Assets[0]`
- `dependencies` (`BepInEx.ConfigurationManager` 18.4.1) carried forward explicitly, since a hand-written entry doesn't inherit them

Validated locally against `ValidationSchema.json`: parses, all required fields present, key set identical to the sibling artifact, LF endings, no BOM.

### Expected CI failure

`Validate-JsonContent.ps1` will report `Id NuclearOption-MouseAim is NOT UNIQUE!` and exit 1. That's `Validate-IdAlreadyExists` — a new-submission check that the PR workflow also runs on updates, so it trips for any mod already in `manifest/manifest.json`. Same situation as #210, which was merged.

### Policy

Source is open and unobfuscated (<https://github.com/cosistra/wt-mouse-aim>); the DLL is built from the tagged commit. `v0.68.0` was flown on 0.34 in both a fixed-wing aircraft and a helicopter before release.
