### PR TITLE
Add MusicRandomizer manifest

### DIFF
--- a/modManifests/MusicRandomizer.json
+++ b/modManifests/MusicRandomizer.json
@@ -24,7 +24,7 @@
       "version": "0.2.0",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.33",
+      "gameVersion": "0.34",
       "downloadUrl": "https://github.com/lucaspevidor/NuclearOptionMusicRandomizer/releases/download/v0.2.0/MusicRandomizer.dll",
       "hash": "sha256:63ca906086784554adc354fedabc2628e921c36b1aa840a5061f0245bb62c224"
     }

--- a/modManifests/MusicRandomizer.json
+++ b/modManifests/MusicRandomizer.json
@@ -1,0 +1,32 @@
+{
+  "id": "MusicRandomizer",
+  "displayName": "Music Randomizer",
+  "description": "Replays and randomizes aircraft takeoff music, with a configurable cooldown between aircraft songs.",
+  "tags": [
+    "QoL",
+    "Flavor"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/lucaspevidor/NuclearOptionMusicRandomizer"
+    }
+  ],
+  "authors": [
+    "Lucas Pevidor"
+  ],
+  "githubOwner": "lucaspevidor",
+  "githubRepoName": "NuclearOptionMusicRandomizer",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "MusicRandomizer.dll",
+      "version": "0.2.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.33",
+      "downloadUrl": "https://github.com/lucaspevidor/NuclearOptionMusicRandomizer/releases/download/v0.2.0/MusicRandomizer.dll",
+      "hash": "sha256:63ca906086784554adc354fedabc2628e921c36b1aa840a5061f0245bb62c224"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds MusicRandomizer to the NOMNOM registry.

MusicRandomizer changes aircraft takeoff music behavior in Nuclear Option. It allows aircraft songs to play on subsequent takeoffs, randomizes tracks across available aircraft by default, and applies a configurable cooldown between aircraft songs.

## Release

- Version: `0.2.0`
- Type: BepInEx plugin
- Game version: `0.34`
- Repository: https://github.com/lucaspevidor/NuclearOptionMusicRandomizer
- Release: https://github.com/lucaspevidor/NuclearOptionMusicRandomizer/releases/tag/v0.2.0

## Validation

- Manifest content validation passed locally.
- Release asset was downloaded and its SHA-256 hash matches the manifest.
- Full schema validation will run through the repository's GitHub Actions workflow.