### PR TITLE
Add AShM-500 Yashma

### DIFF
--- a/modManifests/AShM500Yashma.json
+++ b/modManifests/AShM500Yashma.json
@@ -1,0 +1,37 @@
+{
+  "id": "AShM500Yashma",
+  "displayName": "AShM-500 Yashma",
+  "description": "A ramjet powered supersonic anti-ship cruise missile. Nine and a half metres, three tonnes, Mach 2.4 on the deck and well past Mach 3 lofted. Sea skimming with terrain following, three switchable flight profiles, salvo spread that fans and reconverges, a staged infra red signature and a shallow terminal weave. Carried by the Darkreach, Multirole1 and FastBomber1, and by three modded aircraft if you have them.",
+  "tags": [
+    "mod",
+    "Weapon",
+    "blueprinter"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/mosdef31/NO-AShM-500-Yashma/blob/main/README.md"
+    }
+  ],
+  "authors": [
+    "mosdef31"
+  ],
+  "githubOwner": "mosdef31",
+  "githubRepoName": "NO-AShM-500-Yashma",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "AShM500Yashma_1.0.0.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "addon",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/mosdef31/NO-AShM-500-Yashma/releases/download/v1.0.0/AShM500Yashma_1.0.0.zip",
+      "hash": "sha256:1aa710b31590d3425b72d76df0df63822033116f0454f0768e2532ce724b48f9",
+      "extends": {
+        "id": "com.nikkorap.blueprinter",
+        "version": "1.8.21"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Hello, and thank you for maintaining the registry.

This adds a manifest for **AShM-500 Yashma**, a Blueprinter addon that adds a ramjet powered supersonic anti-ship cruise missile. It is carried by the Darkreach, Multirole1 and FastBomber1, and optionally by a few modded aircraft when those are installed.

- Mod repo: https://github.com/mosdef31/NO-AShM-500-Yashma
- Release: https://github.com/mosdef31/NO-AShM-500-Yashma/releases/tag/v1.0.0

A few notes on how I filled it in, in case any of it is not to your liking:

- I followed `155mmRailgun.json` as the closest existing example, since it is also a Blueprinter weapon addon. So `"type": "addon"`, the `"sha256:"` prefixed hash form, and an `extends` block naming `com.nikkorap.blueprinter`.
- The artifact is a zip because this mod ships two files that have to land together, `AShM500Mod.dll` and `ashm500.nobp`. The loose files are also attached to the release if a single file artifact would suit the manager better, and I am happy to change the entry to whichever form you prefer.
- The hash is of the published zip and I verified it against the actual download rather than my local copy.
- Requires Nuclear Option 0.34+ and Blueprinter 1.8.21.

I am the author of the mod. Happy to adjust anything here, including the id, tags or description, if they do not fit the conventions you would rather the registry kept. Thanks for taking a look.
