### PR TITLE
Add Show Airbases

### DIFF
--- a/modManifests/NO_ShowAirbases.json
+++ b/modManifests/NO_ShowAirbases.json
@@ -1,0 +1,44 @@
+{
+  "id": "NO_ShowAirbases",
+  "displayName": "Show Airbases",
+  "description": "Allows showing airbase icons while spawned in. Toggled in Bepinex config, or with an optionally assigned hotkey when Extra Input Framework is loaded (supports hold and toggle modes).",
+  "tags": [
+    "mod",
+    "QoL",
+    "UI",
+    "Map"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/Appulcake/NO_ShowAirbases"
+    },
+    {
+      "name": "Extra Input Framework",
+      "url": "https://github.com/Assassin1076/NuclearOptionInputFramework"
+    }
+  ],
+  "authors": [
+    "Appulcake"
+  ],
+  "githubOwner": "Appulcake",
+  "githubRepoName": "NO_ShowAirbases",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "NO_ShowAirbases.dll",
+      "version": "0.34.1.1",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.1",
+      "downloadUrl": "https://github.com/Appulcake/NO_ShowAirbases/releases/download/v0.34.1.1/NO_ShowAirbases.dll",
+      "hash": "sha256:7921ee863ed51facae15b5c84bb8bb38a8578cf3faf2a71470fbc94dafa3de90",
+      "dependencies": [
+        {
+          "id": "BepInEx.ConfigurationManager",
+          "version": "18.4.1"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a small little utility mod called Show Airbases, that allows players to show airbase icons at all times when spawned in, as especially for new players it can be a struggle to remember names of airbases.
It has a soft dependency on Assassin1076's Extra Input Framework (https://github.com/Assassin1076/NuclearOptionInputFramework) that when present, gets called to register a rewired keybind to native keybinds menu, but otherwise is optional and works without it too.

Mod's repo: https://github.com/Appulcake/NO_ShowAirbases
Releases at: https://github.com/Appulcake/NO_ShowAirbases/releases