### PR TITLE
InputFramework + ShowAirbases dependency

### DIFF
--- a/modManifests/InputFramework.json
+++ b/modManifests/InputFramework.json
@@ -1,0 +1,33 @@
+{
+  "id": "InputFramework",
+  "displayName": "Extra Input Framework",
+  "description": "A framework / API to provide extra input registration for other mods to use.",
+  "tags": [
+    "Utility",
+    "Framework",
+    "API"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/Assassin1076/NuclearOptionInputFramework"
+    }
+  ],
+  "authors": [
+    "Assassin1076"
+  ],
+  "githubOwner": "Assassin1076",
+  "githubRepoName": "NuclearOptionInputFramework",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "Extra.Input.Framework.Mod.v0.0.2.zip",
+      "version": "0.0.2",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.1",
+      "downloadUrl": "https://github.com/Assassin1076/NuclearOptionInputFramework/releases/download/v0.0.2/Extra.Input.Framework.Mod.v0.0.2.zip",
+      "hash": "sha256:405a157838cba3ae1b516e114c42f4bd38959cdbc498bb5d166264928a6b7c26"
+    }
+  ]
+}

--- a/modManifests/NO_ShowAirbases.json
+++ b/modManifests/NO_ShowAirbases.json
@@ -37,6 +37,10 @@
         {
           "id": "BepInEx.ConfigurationManager",
           "version": "18.4.1"
+        },
+        {
+          "id": "InputFramework",
+          "version": "0.0.2"
         }
       ]
     }


### PR DESCRIPTION
This is a submission on behalf of Assassin1076, from this thread: https://discord.com/channels/909034158205059082/1483822177261322430

On their mod Extra Input Framework that's an input API other mods can use and call to simplify registering native Rewired inputs.

I've talked with Assassin1076 in their mod's thread about this on how it'd be useful and that I'd like to interface for them on this (them and the Chinese community doesn't tend to use NOMM), and gave me permission to help out with doing this (https://discord.com/channels/909034158205059082/1483822177261322430/1534603572505739315).

Also contains a small adjustment to my own mod, that'd go in tandem with Extra Input being approved to NOMNOM, to mark it as a dependency.