### PR TITLE
Add MissileCamera mod manifest

### DIFF
--- a/modManifests/MissileCamera.json
+++ b/modManifests/MissileCamera.json
@@ -1,0 +1,32 @@
+{
+  "id": "MissileCamera",
+  "displayName": "Missile Camera",
+  "description": "Live missile seeker feed on MFD and fullscreen gunship HUD for Nuclear Option (BepInEx 5).",
+  "tags": [
+    "QoL",
+    "Camera"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/Mursisru/MissileCamera"
+    }
+  ],
+  "authors": [
+    "Mursisru"
+  ],
+  "githubOwner": "Mursisru",
+  "githubRepoName": "MissileCamera",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "MissileCamera-2-0-0.zip",
+      "version": "2.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/Mursisru/MissileCamera/releases/download/v2.0.0/MissileCamera-2-0-0.zip",
+      "hash": "sha256:0ece977a524ed76bf99b79704e661fdf9f3dea74cddcaafa9e558d36b0640c56"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Register **MissileCamera** (`id`: MissileCamera) for NOMM via NOMNOM.
- Initial artifact: **2.0.0** from https://github.com/Mursisru/MissileCamera/releases/tag/v2.0.0 (`MissileCamera-2-0-0.zip`).
- Auto-update enabled: `githubOwner` / `githubRepoName` / `autoUpdateArtifacts: True`.

## Compliance
- Open-source MIT BepInEx 5 plugin (no obfuscation): https://github.com/Mursisru/MissileCamera
- One mod per repository; first release asset is the NOMNOM zip.
- Parseable release tag: `v2.0.0`
- Distinct from existing **MissileCamNO** (different author/repo).