### PR TITLE
Add AGR-31 Tenpin

### DIFF
--- a/modManifests/AGR31Tenpin.json
+++ b/modManifests/AGR31Tenpin.json
@@ -1,0 +1,39 @@
+{
+  "id": "AGR31Tenpin",
+  "displayName": "AGR-31 Tenpin",
+  "description": "Air launched saturation rocket artillery, in a light 7 tube pod and a heavy 19 tube pod. An unguided 90 mm rocket, 12 to 15 km lofted, rippling at 0.08 s so six pods put 42 rounds in the air in about three seconds or 114 in about nine. Counter SHORAD from standoff, with light anti armour on a direct hit. Draws its own weapon HUD: an artillery mode with ground designation, predicted impact, salvo footprint and a release cue, and a direct mode with a continuously computed impact point. Carried by the A-19, SAH-46 Chicane, UH-90 Ibis, T/A-30 Compass and VT-7 Vagrant. Requires Blueprinter. The asset bundle ships inside the DLL, so it is one file.",
+  "tags": [
+    "mod",
+    "Weapon",
+    "blueprinter"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/mosdef31/NO-AGR-31-Tenpin/blob/main/README.md"
+    }
+  ],
+  "authors": [
+    "mosdef31"
+  ],
+  "githubOwner": "mosdef31",
+  "githubRepoName": "NO-AGR-31-Tenpin",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "TenpinMod.dll",
+      "version": "0.9.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/mosdef31/NO-AGR-31-Tenpin/releases/download/v0.9.0/TenpinMod.dll",
+      "hash": "sha256:41c79a01a557936605a556816877a63a72d8d8fffc559cc1ca025f88a1597ba7",
+      "dependencies": [
+        {
+          "id": "com.nikkorap.blueprinter",
+          "version": "1.8.21"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds `modManifests/AGR31Tenpin.json`.

AGR-31 Tenpin, an air launched rocket artillery weapon in a 7 tube and a 19 tube pod. Blueprinter addon shipped as a BepInEx plugin: the asset bundle is an embedded resource inside `TenpinMod.dll`, so the release is one file.

- Repo: https://github.com/mosdef31/NO-AGR-31-Tenpin (public, source under CC BY 4.0)
- Release: https://github.com/mosdef31/NO-AGR-31-Tenpin/releases/tag/v0.9.0
- Asset `TenpinMod.dll`, sha256 `41c79a01a557936605a556816877a63a72d8d8fffc559cc1ca025f88a1597ba7`, verified against an anonymous download
- Game version 0.34, BepInEx 5, requires Blueprinter 1.8.21
- Validates against `ValidationSchema.json`

One thing to check on your side: the artifact is `type: plugin` with a `dependencies` entry for Blueprinter, rather than `type: addOn` with `extends`. It carries a bundle, but the file itself has to land in `BepInEx/plugins` for BepInEx to load it. Happy to switch it if that is not how the manager treats the two.