### PR TITLE
Create Sitrep.json for SITREP mod metadata

### DIFF
--- a/modManifests/NOVor.json
+++ b/modManifests/NOVor.json
@@ -1,0 +1,24 @@
+{
+  "id": "NOVor",
+  "displayName": "NO VOR CDI",
+  "description": "VOR-style cockpit HUD CDI plus a searchable navigation panel with heading-up HSI, airport ownership, runway courses, and live diversion telemetry.",
+  "tags": ["mod", "QoL", "HUD", "Navigation"],
+  "urls": [
+    { "name": "info", "url": "https://github.com/kkingsbe/no-vor" }
+  ],
+  "authors": ["kkingsbe"],
+  "githubOwner": "kkingsbe",
+  "githubRepoName": "no-vor",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "novor-1.0.0.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/kkingsbe/no-vor/releases/download/v1.0.0/novor-1.0.0.zip",
+      "hash": "sha256:5b2f92e108a326c96f66b54da1b2c3e89c62e9ec7738a9c1167d9100821ba87e"
+    }
+  ]
+}

--- a/modManifests/NoModBar.json
+++ b/modManifests/NoModBar.json
@@ -1,0 +1,27 @@
+{
+  "id": "NoModBar",
+  "displayName": "NO Mod Bar",
+  "description": "A KSP-style persistent toolbar for Nuclear Option. Any mod's panel can register with the bar and be opened/closed by clicking its button; hold Left Alt while flying to free the mouse cursor.",
+  "tags": ["mod", "QoL", "UI"],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/kkingsbe/no-modbar"
+    }
+  ],
+  "authors": ["kkingsbe"],
+  "githubOwner": "kkingsbe",
+  "githubRepoName": "no-modbar",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "nomodbar-1.0.0.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/kkingsbe/no-modbar/releases/download/v1.0.0/nomodbar-1.0.0.zip",
+      "hash": "sha256:d642242bb836ab78e33f8e50982972a4813d0da2b23328044d833e649ed83393"
+    }
+  ]
+}

--- a/modManifests/Sitrep.json
+++ b/modManifests/Sitrep.json
@@ -1,0 +1,24 @@
+{
+  "id": "Sitrep",
+  "displayName": "SITREP",
+  "description": "Reads in-game chat aloud via Kokoro TTS with an optional radio DSP effect and chat overlay.",
+  "tags": ["mod", "QoL", "voice"],
+  "urls": [
+    { "name": "info", "url": "https://github.com/kkingsbe/sitrep" }
+  ],
+  "authors": ["kkingsbe"],
+  "githubOwner": "kkingsbe",
+  "githubRepoName": "sitrep",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "sitrep-1.0.0.zip",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/kkingsbe/sitrep/releases/download/v1.0.0/sitrep-1.0.0.zip",
+      "hash": "sha256:81a7192c8b138162096000b2d6608eb089316eca2fafc29cb350f00d1ead84ea"
+    }
+  ]
+}


### PR DESCRIPTION
Added a JSON manifest for the SITREP mod, including metadata such as description, authors, and download information.