### PR TITLE
Update Radar Missile Control description for v0.5.1

### DIFF
--- a/modManifests/blacknight2u.sarhcontrol.json
+++ b/modManifests/blacknight2u.sarhcontrol.json
@@ -1,7 +1,7 @@
 {
   "id": "blacknight2u.sarhcontrol",
   "displayName": "Radar Missile Control",
-  "description": "Host-configurable radar missile rules for SARH and ARH weapons. Press F7 to choose player/AI launch-target routes and adjust guidance, accuracy, thrust, and speed; F8 cycles OFF (VANILLA), NERFED, and DISABLED. Gameplay remains host-authoritative.",
+  "description": "Host-controlled SARH and ARH missile presets. Press F7 to configure missile types, AI/player engagements, guidance, accuracy, thrust, and speed. Press F8 to cycle Vanilla, Preset 1, and Preset 2. Multiplayer settings remain host-authoritative.",
   "tags": [
     "gameplay",
     "difficulty",
@@ -25,13 +25,13 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "SARHControl-v0.5.0.zip",
-      "version": "0.5.0",
+      "fileName": "SARHControl-v0.5.1.zip",
+      "version": "0.5.1",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.34.1",
-      "downloadUrl": "https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/download/v0.5.0/SARHControl-v0.5.0.zip",
-      "hash": "sha256:f7c7aa9a0d83c92cadcdf53a80fc171372662070f086e14a9cb855c982c725ba",
+      "downloadUrl": "https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/download/v0.5.1/SARHControl-v0.5.1.zip",
+      "hash": "sha256:eb96fee5f5d05229d4473f42c40e613d444b38f43a3caf001862592c811b1fed",
       "dependencies": [],
       "incompatibilities": []
     }

--- a/modManifests/blacknight2u.sarhcontrol.json
+++ b/modManifests/blacknight2u.sarhcontrol.json
@@ -25,13 +25,13 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "SARHControl-v0.5.1.zip",
-      "version": "0.5.1",
+      "fileName": "SARHControl-v0.5.0.zip",
+      "version": "0.5.0",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.34.1",
-      "downloadUrl": "https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/download/v0.5.1/SARHControl-v0.5.1.zip",
-      "hash": "sha256:eb96fee5f5d05229d4473f42c40e613d444b38f43a3caf001862592c811b1fed",
+      "downloadUrl": "https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/download/v0.5.0/SARHControl-v0.5.0.zip",
+      "hash": "sha256:f7c7aa9a0d83c92cadcdf53a80fc171372662070f086e14a9cb855c982c725ba",
       "dependencies": [],
       "incompatibilities": []
     }


### PR DESCRIPTION
## Summary

Updates the existing **Radar Missile Control** store description for its v0.5.1 preset workflow.

- Keeps the stable internal ID `blacknight2u.sarhcontrol` (required to match the manifest filename)
- Keeps the human-readable `displayName` as **Radar Missile Control**
- Describes the Vanilla / Preset 1 / Preset 2 workflow and host-authoritative multiplayer behavior
- Changes no ownership metadata, artifact history, or download-count data

The v0.5.1 release is already published at:
https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/tag/v0.5.1

Because this registered manifest has `autoUpdateArtifacts: "True"`, NOMNOM's hourly workflow should discover and append the v0.5.1 artifact automatically. The public asset was re-downloaded and verified at SHA-256 `eb96fee5f5d05229d4473f42c40e613d444b38f43a3caf001862592c811b1fed`.

## Validation note

The manifest JSON and schema are valid. The changed-file workflow rejects edits to any existing manifest as "ID is NOT UNIQUE" because it compares the edited ID against the generated current registry. Recent existing-manifest corrections (for example #222 and #234) were reviewed and merged despite that same validator behavior. The final PR diff is intentionally limited to one description line.