### PR TITLE
Change Nuclear Option VWS Display Name

### DIFF
--- a/modManifests/LockToneShootPing.json
+++ b/modManifests/LockToneShootPing.json
@@ -43,7 +43,7 @@
       "version": "1.2.1",
       "category": "Release",
       "type": "plugin",
-      "gameVersion": "0.33",
+      "gameVersion": "0.34",
       "downloadUrl": "https://github.com/Aeriicatmeow/Lock-Shoot-Tone-Ping/releases/download/v.1.2.1/Lock_Shoot_Tone_Ping.dll",
       "hash": "sha256:E78F676FA04AB9F3E4338ACC760AAC99A05E7192098715B3C5D18A29A73B4C15"
     }

--- a/modManifests/LockToneShootPing.json
+++ b/modManifests/LockToneShootPing.json
@@ -43,7 +43,7 @@
       "version": "1.2.1",
       "category": "Release",
       "type": "plugin",
-      "gameVersion": "0.34",
+      "gameVersion": "0.34.2",
       "downloadUrl": "https://github.com/Aeriicatmeow/Lock-Shoot-Tone-Ping/releases/download/v.1.2.1/Lock_Shoot_Tone_Ping.dll",
       "hash": "sha256:E78F676FA04AB9F3E4338ACC760AAC99A05E7192098715B3C5D18A29A73B4C15"
     }

--- a/modManifests/LockToneShootPing.json
+++ b/modManifests/LockToneShootPing.json
@@ -43,7 +43,7 @@
       "version": "1.2.1",
       "category": "Release",
       "type": "plugin",
-      "gameVersion": "0.34.2",
+      "gameVersion": "0.34.1",
       "downloadUrl": "https://github.com/Aeriicatmeow/Lock-Shoot-Tone-Ping/releases/download/v.1.2.1/Lock_Shoot_Tone_Ping.dll",
       "hash": "sha256:E78F676FA04AB9F3E4338ACC760AAC99A05E7192098715B3C5D18A29A73B4C15"
     }

--- a/modManifests/NuclearOptionVWS.json
+++ b/modManifests/NuclearOptionVWS.json
@@ -1,6 +1,6 @@
 {
   "id": "NuclearOptionVWS",
-  "displayName": "Nuclear Option VWS",
+  "displayName": "Nuclear Option Voice Warning System",
   "description": "This mod expands on the voice warning system in the base game adding a variety of callouts for external hazards (such as enemy aircraft, missiles or ground units) and internal hazards (Such as altitude warnings, AoA and Gforce warnings as well as recommendation for ejection). Mod contains a pack handling system allowing for the quick import of audio and settings. Instructions on how to use mod are present in the README on Github.",
   "tags": [
     "Sound",
@@ -25,7 +25,7 @@
       "version": "1.1.2",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.34",
+      "gameVersion": "0.34.2",
       "downloadUrl": "https://github.com/Aeriicatmeow/Nuclear-Option-Voice-Warning-System/releases/download/v1.1.2/NuclearOption-VWS.zip",
       "hash": "sha256:61a4c1b96f1dddd41adc315d55e319f277ca2f2678322c74d82a0eda8e269d14"
     },
@@ -34,7 +34,7 @@
       "version": "1.1.1",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.34",
+      "gameVersion": "0.34.2",
       "downloadUrl": "https://github.com/Aeriicatmeow/Nuclear-Option-Voice-Warning-System/releases/download/v1.1.1/NuclearOption-VWS.zip",
       "hash": "sha256:769e8c774ef1530c1adb8807889aa14f07d2aaffa575f58f5e27c0472052d04e"
     },
@@ -43,7 +43,7 @@
       "version": "1.1.0",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.34",
+      "gameVersion": "0.34.2",
       "downloadUrl": "https://github.com/Aeriicatmeow/Nuclear-Option-Voice-Warning-System/releases/download/v1.1.0/NuclearOption-VWS.zip",
       "hash": "sha256:1a8f4bff02d71616259b91627a274a980d674117750341f44da69ce389fe9868"
     },
@@ -52,7 +52,7 @@
       "version": "1.0.0",
       "category": "Release",
       "type": "plugin",
-      "gameVersion": "0.34",
+      "gameVersion": "0.34.2",
       "downloadUrl": "https://github.com/Aeriicatmeow/Nuclear-Option-Voice-Warning-System/releases/download/v1.0.0/NuclearOption-VWS.zip",
       "hash": "sha256:41c19bc61c8fcfcbe50be7f7e6e449366884bd89f175812de6a172e6eb7330ac"
     }

--- a/modManifests/NuclearOptionVWS.json
+++ b/modManifests/NuclearOptionVWS.json
@@ -43,7 +43,7 @@
       "version": "1.1.0",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.34.2",
+      "gameVersion": "0.34.1",
       "downloadUrl": "https://github.com/Aeriicatmeow/Nuclear-Option-Voice-Warning-System/releases/download/v1.1.0/NuclearOption-VWS.zip",
       "hash": "sha256:1a8f4bff02d71616259b91627a274a980d674117750341f44da69ce389fe9868"
     },
@@ -52,7 +52,7 @@
       "version": "1.0.0",
       "category": "Release",
       "type": "plugin",
-      "gameVersion": "0.34.2",
+      "gameVersion": "0.34.1",
       "downloadUrl": "https://github.com/Aeriicatmeow/Nuclear-Option-Voice-Warning-System/releases/download/v1.0.0/NuclearOption-VWS.zip",
       "hash": "sha256:41c19bc61c8fcfcbe50be7f7e6e449366884bd89f175812de6a172e6eb7330ac"
     }


### PR DESCRIPTION
Changed Nuclear Option VWS Display Name
Nuclear Option VWS -> Nuclear Option Voice Warning System

To bring parity with the github and discord entries on this mod.

Changed the version number for the final update of Lock Tone Shoot Ping from 0.33 to 0.34.1 which was the last version i tested the mod on after releasing an update that made it compatible with 0.34.1 on August 5th.

Changed the version numbers on the previous installments of Nuclear Option VWS.
On the updates pushed before midnight today (BST), i have marked them as 0.34.1
On all updates pushed after midnight today, I have marked them as 0.34.2
Either way, I have found the VWS to work in the new update

No other changes have been made.

I apologize for having made two PRs in such a short time window


Regards,
Aerii