### PR TITLE
Fix Game Version Error On LockToneShootPing

### DIFF
--- a/modManifests/LockToneShootPing.json
+++ b/modManifests/LockToneShootPing.json
@@ -25,7 +25,7 @@
       "version": "1.2.3",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.33",
+      "gameVersion": "0.34.1",
       "downloadUrl": "https://github.com/Aeriicatmeow/Lock-Shoot-Tone-Ping/releases/download/v1.2.3/Lock_Shoot_Tone_Ping.dll",
       "hash": "sha256:663ff67bc2452d2751609ed94a30df3fce3c1d6a818d39ba491023b309fa4a8d"
     },
@@ -43,7 +43,7 @@
       "version": "1.2.1",
       "category": "Release",
       "type": "plugin",
-      "gameVersion": "0.34.1",
+      "gameVersion": "0.33",
       "downloadUrl": "https://github.com/Aeriicatmeow/Lock-Shoot-Tone-Ping/releases/download/v.1.2.1/Lock_Shoot_Tone_Ping.dll",
       "hash": "sha256:E78F676FA04AB9F3E4338ACC760AAC99A05E7192098715B3C5D18A29A73B4C15"
     }


### PR DESCRIPTION
Fix error in version Number
I apologize for yet another PR

I made an error in changing the version numbers. Most recent version is at the top of the version list. not the bottom.

LTSP 1.2.3 is rated for 0.34.1
the other versions are for 0.33
this change reflect that

note: in my last PR, I set v1.2.1 to be 0.34.1 rated which isnt that case.

Again, I apologize for making another PR on such a small issue.