### PR TITLE
Mark Radar Missile Control compatible with Nuclear Option 0.34.2

### DIFF
--- a/modManifests/blacknight2u.sarhcontrol.json
+++ b/modManifests/blacknight2u.sarhcontrol.json
@@ -29,7 +29,7 @@
       "version": "0.5.1",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.34.1",
+      "gameVersion": "0.34.2",
       "downloadUrl": "https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/download/v0.5.1/SARHControl-v0.5.1.zip",
       "hash": "sha256:eb96fee5f5d05229d4473f42c40e613d444b38f43a3caf001862592c811b1fed"
     },


### PR DESCRIPTION
## Summary

Marks **Radar Missile Control v0.5.1** as compatible with Nuclear Option 0.34.2.

This changes only the latest artifact's `gameVersion` from `0.34.1` to `0.34.2`. The mod ID, display name, release URL, SHA-256, historical v0.5.0 entry, and download count remain unchanged.

## Compatibility verification

- Tested against installed Steam build `24724372`
- v0.5.1 loaded on 0.34.2 without plugin, Harmony, missing-method, or type-load errors
- Clean warnings-as-errors build against the updated assemblies: 0 warnings, 0 errors
- All Harmony target methods and reflected seeker/missile fields retain the expected names, types, and signatures
- Published v0.5.1 and a fresh 0.34.2 build have identical normalized IL and assembly-reference identities

No replacement DLL or new release is required. The audit is documented in the source repository at commit `91e1e120ba12e6eccfa8d32b8f4dd7dbbb94e477`.

## Validator note

NOMNOM's changed-file validator currently reports existing-manifest edits as `ID is NOT UNIQUE` because it compares the edited ID with the generated registry. This PR intentionally retains the stable existing ID and changes one compatibility field only.