### PR TITLE
Allow validation of existing manifest updates

### DIFF
--- a/Validate-JsonContent.ps1
+++ b/Validate-JsonContent.ps1
@@ -67,21 +67,8 @@ function Validate-RelationId
 function Validate-IdMatchesFileName
 {
     Param($id)
-    $idMatchesFilename = ((get-item $Path).Name -replace ".json","") -eq $id
-    if (!$idMatchesFilename){
-        return $false
-    }
-    return $true
-}
-
-function Validate-IdAlreadyExists
-{
-    Param($id)
-    $check = $ModManifestHashTable["$id"]
-    if ($check){
-        return $false
-    }
-    return $true
+    $expectedId = [IO.Path]::GetFileNameWithoutExtension($Path)
+    return $expectedId -ceq $id
 }
 
 function Validate-Relation
@@ -147,13 +134,12 @@ try
     Write-Host "Validating $($parsedMod.id)..."
     #$parsedMod
 
-    Write-Host "Validating Id matches file name: $($parsedMod.id) $((get-item $Path).Name): $(Validate-IdMatchesFileName -id $parsedMod.id)"
-    $isIdUnique = Validate-IdAlreadyExists -id $parsedMod.Id
-    Write-Host "Validating Id is Unique: $($parsedMod.id): $isIdUnique"
-    if (!$isIdUnique)
+    $fileName = (Get-Item $Path).Name
+    $idMatchesFileName = Validate-IdMatchesFileName -id $parsedMod.id
+    Write-Host "Validating Id matches file name: $($parsedMod.id) $fileName`: $idMatchesFileName"
+    if (!$idMatchesFileName)
     {
-        Write-Host $("Id $($parsedMod.id) is NOT UNIQUE!")
-        Exit 1
+        LogError("Manifest Id '$($parsedMod.id)' must match file name '$fileName'.")
     }
     Write-Host "Validating urls $($parsedMod.urls): $(Validate-urls -urls $parsedMod.urls)"
     Write-Host "Validating dependencies..."


### PR DESCRIPTION
## Problem

The validation workflow checks changed manifests against the already-published compiled manifest. Any legitimate update therefore fails as a duplicate because its ID already exists. PR #278 is currently failing for this reason even though its schema and filename are valid.

The script already reports whether the ID matches the filename, but did not enforce that result.

## Change

- make the manifest filename the stable identity for both new submissions and updates
- require the ID to exactly match that filename
- remove the compiled-manifest uniqueness check that rejects every update

A duplicate ID submitted under another filename still fails because its ID cannot match that filename.

## Verification

Tested the script with four cases:

- existing manifest update: passes
- new unique manifest: passes
- existing ID under another filename: fails
- mismatched ID and filename: fails

Audited all 157 current source manifests: 0 filename/ID mismatches and 0 duplicate IDs.