### PR TITLE
Add KaceyTronic-RWR mod manifest

### DIFF
--- a/modManifests/KaceyTronic-RWR.json
+++ b/modManifests/KaceyTronic-RWR.json
@@ -1,0 +1,34 @@
+{
+  "id": "KaceyTronic-RWR",
+  "displayName": "KaceyTronic-RWR",
+  "description": "Enhanced on-visor Radar Warning Receiver (RWR) overlay with rank-based fidelity, a TGT/MSL/SEEN/HI-LO threat warning panel, and Rank 0 corner indicators.",
+  "tags": [
+    "mod",
+    "QoL",
+    "HUD"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/KcTries/KaceyTronic-RWR"
+    }
+  ],
+  "authors": [
+    "KcTries"
+  ],
+  "isClientOrServer": "Client",
+  "githubOwner": "KcTries",
+  "githubRepoName": "KaceyTronic-RWR",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "KaceyTronic-RWR-1.3.0.dll",
+      "version": "1.3.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/KcTries/KaceyTronic-RWR/releases/download/v1.3.0/KaceyTronic-RWR-1.3.0.dll",
+      "hash": "sha256:571ad2daa961de9cdd9c56df23a983369ed06423452306433c410ddb331e8b50"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a manifest entry for KaceyTronic-RWR, an enhanced on-visor RWR overlay mod for Nuclear Option.

- Repo: https://github.com/KcTries/KaceyTronic-RWR
- Latest release: v1.3.0 (0.34.2)
- Source is fully open, single BepInEx plugin DLL, one release asset

Validated locally against `ValidationSchema.json` and `Validate-JsonContent.ps1` (id unique, filename/URL/version/gameVersion all pass).