### PR TITLE
Add manifest for NoWingmen v1.0.0

### DIFF
--- a/modManifests/NoWingmen.json
+++ b/modManifests/NoWingmen.json
@@ -1,0 +1,38 @@
+{
+  "id": "NoWingmen",
+  "displayName": "NoWingmen",
+  "description": "Wing, friends and team visuals with extra features.",
+  "tags": [
+    "mod",
+    "QoL",
+    "HUD",
+    "multiplayer",
+    "wingman",
+    "friends",
+    "targets"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/NiJeTi/NoWingmen"
+    }
+  ],
+  "authors": [
+    "NiJeTi"
+  ],
+  "isClientOrServer": "Client",
+  "githubOwner": "NiJeTi",
+  "githubRepoName": "NoWingmen",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "NoWingmen.dll",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/NiJeTi/NoWingmen/releases/download/v1.0.0/NoWingmen.dll",
+      "hash": "sha256:d22fe9e8e1f67aacf64bf7abfbb7eaf04e65d3914428b6337a65f58813794398"
+    }
+  ]
+}


### PR DESCRIPTION
Registers [NoWingmen](https://github.com/NiJeTi/NoWingmen) — a client-side BepInEx 5 plugin for Nuclear Option that adds wingman, friend and team visuals on the HUD and map.

**Mod ID:** `NoWingmen` (matches the plugin's AssemblyName and the file name)

### Artifact
- Release: [v1.0.0](https://github.com/NiJeTi/NoWingmen/releases/tag/v1.0.0), single asset `NoWingmen.dll`
- `sha256:d22fe9e8e1f67aacf64bf7abfbb7eaf04e65d3914428b6337a65f58813794398` (verified against the downloaded asset)
- Version matches the DLL's assembly metadata (1.0.0)
- `gameVersion`: 0.34.2
- No dependencies beyond BepInEx 5 itself
- `autoUpdateArtifacts` enabled

### Acceptance Policy
- Fully open source under Apache-2.0, no obfuscation: https://github.com/NiJeTi/NoWingmen
- One mod per repository, delivered as a GitHub release asset
- Tag follows `vX.Y.Z`
- Client-side and visual only — no effect on the server