### PR TITLE
Add Nuclear Option Detents v0.1.0 manifest

### DIFF
--- a/modManifests/NuclearOptionDetents.json
+++ b/modManifests/NuclearOptionDetents.json
@@ -1,0 +1,33 @@
+{
+  "id": "NuclearOptionDetents",
+  "displayName": "Nuclear Option Detents",
+  "description": "Adds configurable hold detents at idle airbrake and full-dry/afterburner changeovers for supported aircraft using relative throttle controls.",
+  "tags": [
+    "QoL",
+    "Gameplay"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/baanish/NO-Throttle-Detents"
+    }
+  ],
+  "authors": [
+    "baanish"
+  ],
+  "isClientOrServer": "Client",
+  "githubOwner": "baanish",
+  "githubRepoName": "NO-Throttle-Detents",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "NuclearOptionDetents-v0.1.0-nomm.zip",
+      "version": "0.1.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/baanish/NO-Throttle-Detents/releases/download/v0.1.0/NuclearOptionDetents-v0.1.0-nomm.zip",
+      "hash": "sha256:b57ff0cae168fccb1b6e927d4b9bc2681f244b70c5c6e40b28d6d01eb82d3011"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This adds the client-side Nuclear Option Detents v0.1.0 plugin.

It provides configurable hold detents for supported relative-throttle aircraft.

The release archive is publicly downloadable and its SHA-256 was verified.

The manifest passed the repository’s validation.

No claim is being made about multiplayer approval or safety.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22391303-595d-4cef-956a-9d73dd8aacb4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22391303-595d-4cef-956a-9d73dd8aacb4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

