### PR TITLE
Add manifest for NoSmoothTime v1.1.0

### DIFF
--- a/modManifests/NoSmoothTime.json
+++ b/modManifests/NoSmoothTime.json
@@ -1,0 +1,35 @@
+{
+  "id": "NoSmoothTime",
+  "displayName": "NoSmoothTime",
+  "description": "Smooth per-frame global lighting for dynamic day-night cycles.",
+  "tags": [
+    "mod",
+    "QoL",
+    "Visual",
+    "lighting"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/NiJeTi/NoSmoothTime"
+    }
+  ],
+  "authors": [
+    "NiJeTi"
+  ],
+  "isClientOrServer": "Client",
+  "githubOwner": "NiJeTi",
+  "githubRepoName": "NoSmoothTime",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "NoSmoothTime.dll",
+      "version": "1.1.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/NiJeTi/NoSmoothTime/releases/download/v1.1.0/NoSmoothTime.dll",
+      "hash": "sha256:7f4094305adf9fda13233bfb021a706413a50c174a0c7f49d17af5ac58ebfe31"
+    }
+  ]
+}


### PR DESCRIPTION
Registers [NoSmoothTime](https://github.com/NiJeTi/NoSmoothTime) — a client-side BepInEx 5 plugin for Nuclear Option that updates global lighting per frame instead of once per second, removing the visible light and shadow steps on fast (30x/60x) day-night cycles.

**Mod ID:** `NoSmoothTime` (matches the plugin's AssemblyName and the file name)

### Artifact
- Release: [v1.1.0](https://github.com/NiJeTi/NoSmoothTime/releases/tag/v1.1.0), single asset `NoSmoothTime.dll`
- `sha256:7f4094305adf9fda13233bfb021a706413a50c174a0c7f49d17af5ac58ebfe31` (verified against the downloaded asset)
- Version matches the DLL's assembly metadata (1.1.0)
- `gameVersion`: 0.34.2
- No dependencies beyond BepInEx 5 itself
- `autoUpdateArtifacts` enabled

### Acceptance Policy
- Fully open source under MIT, no obfuscation: https://github.com/NiJeTi/NoSmoothTime
- One mod per repository, delivered as a GitHub release asset
- Tag follows `vX.Y.Z`
- Client-side and visual only — no effect on the server
