### PR TITLE
Add Oritasy (com.iallemege.oritasy) 0.0.9.197

### DIFF
--- a/modManifests/com.iallemege.oritasy.json
+++ b/modManifests/com.iallemege.oritasy.json
@@ -1,0 +1,34 @@
+{
+  "id": "com.iallemege.oritasy",
+  "displayName": "Oritasy",
+  "description": "Nuclear Option gameplay pack: hangar aircraft, flight assists, HUD tools, WeXon weapons, TGM-85. Standard Edition C (EN/ZH). Copy zip contents into BepInEx/plugins. Do not also load 197D (same GUID).",
+  "tags": [
+    "Aircraft",
+    "QoL",
+    "Weapons"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/iallemege/Oritasy-System"
+    }
+  ],
+  "authors": [
+    "IAllemege",
+    "qiaochen"
+  ],
+  "githubOwner": "iallemege",
+  "githubRepoName": "Oritasy-System",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "type": "plugin",
+      "fileName": "Oritasy_0.0.9.197C.zip",
+      "downloadUrl": "https://github.com/iallemege/Oritasy-System/releases/download/0.0.9.197C/Oritasy_0.0.9.197C.zip",
+      "hash": "sha256:d0b02131340e8784d73dcc87e6c29c685f1e7dee784df127cf98bdd29e3b8912",
+      "gameVersion": "0.34.2",
+      "version": "0.0.9.197C",
+      "category": "release"
+    }
+  ]
+}

--- a/modManifests/com.iallemege.oritasy.json
+++ b/modManifests/com.iallemege.oritasy.json
@@ -1,7 +1,7 @@
 {
   "id": "com.iallemege.oritasy",
   "displayName": "Oritasy",
-  "description": "Nuclear Option gameplay pack: hangar aircraft, flight assists, HUD tools, WeXon weapons, TGM-85. Standard Edition C (EN/ZH). Copy zip contents into BepInEx/plugins. Do not also load 197D (same GUID).",
+  "description": "Nuclear Option gameplay pack: hangar aircraft, flight assists, HUD tools, WeXon weapons, TGM-85. Standard Edition (EN/ZH). Copy zip contents into BepInEx/plugins. Do not also load the D edition (same GUID).",
   "tags": [
     "Aircraft",
     "QoL",
@@ -20,14 +20,15 @@
   "githubOwner": "iallemege",
   "githubRepoName": "Oritasy-System",
   "autoUpdateArtifacts": "True",
+  "isClientOrServer": "Both",
   "artifacts": [
     {
       "type": "plugin",
       "fileName": "Oritasy_0.0.9.197C.zip",
       "downloadUrl": "https://github.com/iallemege/Oritasy-System/releases/download/0.0.9.197C/Oritasy_0.0.9.197C.zip",
-      "hash": "sha256:d0b02131340e8784d73dcc87e6c29c685f1e7dee784df127cf98bdd29e3b8912",
+      "hash": "sha256:e250c7f8b3d0e44c27d3ec62bd8dd7eb8da6d91f3637e4387a005f3387b8a330",
       "gameVersion": "0.34.2",
-      "version": "0.0.9.197C",
+      "version": "0.0.9.197",
       "category": "release"
     }
   ]


### PR DESCRIPTION
Adds Oritasy to the NOMM catalog.

- id: `com.iallemege.oritasy` (BepInEx GUID)
- artifact version: `0.0.9.197` (`System.Version`)
- file: `Oritasy_0.0.9.197C.zip` from https://github.com/iallemege/Oritasy-System/releases/tag/0.0.9.197C
- hash: `sha256:e250c7f8b3d0e44c27d3ec62bd8dd7eb8da6d91f3637e4387a005f3387b8a330`
- gameVersion: 0.34.2
- autoUpdateArtifacts: True
- isClientOrServer: Both

Zip root is `BepInEx/plugins`. The C in the filename is the Standard (EN/ZH) edition label only; catalog version is numeric so NOMNOM can parse it.