### PR TITLE
Cursor/update nuclear option detents v0.2.0

### DIFF
--- a/Validate-JsonContent.ps1
+++ b/Validate-JsonContent.ps1
@@ -78,10 +78,16 @@ function Validate-IdAlreadyExists
 {
     Param($id)
     $check = $ModManifestHashTable["$id"]
-    if ($check){
-        return $false
+    if (!$check){
+        return $true
     }
-    return $true
+    # The compiled catalog already contains registered mods. An in-place
+    # update of that mod's source file is not a duplicate id.
+    $sourceId = (get-item $Path).Name -replace ".json",""
+    if ($sourceId -eq $id) {
+        return $true
+    }
+    return $false
 }
 
 function Validate-Relation

--- a/modManifests/NuclearOptionDetents.json
+++ b/modManifests/NuclearOptionDetents.json
@@ -23,7 +23,7 @@
     {
       "fileName": "NuclearOptionDetents-v0.2.0-nomm.zip",
       "version": "0.2.0",
-      "category": "release",
+      "category": "preRelease",
       "type": "plugin",
       "gameVersion": "0.34.2",
       "downloadUrl": "https://github.com/baanish/NO-Throttle-Detents/releases/download/v0.2.0/NuclearOptionDetents-v0.2.0-nomm.zip",

--- a/modManifests/NuclearOptionDetents.json
+++ b/modManifests/NuclearOptionDetents.json
@@ -1,7 +1,7 @@
 {
   "id": "NuclearOptionDetents",
   "displayName": "Nuclear Option Detents",
-  "description": "Adds configurable hold detents at idle airbrake and full-dry/afterburner changeovers for supported aircraft using relative throttle controls.",
+  "description": "Adds throttle detents for relative throttle controls: the throttle catches just above 0% and at full dry thrust, giving you a window to release the key before the airbrake or afterburner triggers. Keep holding briefly to push through.",
   "tags": [
     "QoL",
     "Gameplay"
@@ -23,7 +23,7 @@
     {
       "fileName": "NuclearOptionDetents-v0.2.0-nomm.zip",
       "version": "0.2.0",
-      "category": "preRelease",
+      "category": "release",
       "type": "plugin",
       "gameVersion": "0.34.2",
       "downloadUrl": "https://github.com/baanish/NO-Throttle-Detents/releases/download/v0.2.0/NuclearOptionDetents-v0.2.0-nomm.zip",

--- a/modManifests/NuclearOptionDetents.json
+++ b/modManifests/NuclearOptionDetents.json
@@ -41,3 +41,4 @@
   ],
   "downloadCount": 8
 }
+


### PR DESCRIPTION
Refresh the listing description for the published v0.2.0 plugin.