### PR TITLE
Add manifest for NoAbsoluteZoom v1.0.0

### DIFF
--- a/modManifests/NoAbsoluteZoom.json
+++ b/modManifests/NoAbsoluteZoom.json
@@ -1,0 +1,37 @@
+{
+  "id": "NoAbsoluteZoom",
+  "displayName": "NoAbsoluteZoom",
+  "description": "Absolute-axis zoom: the position of a throttle slider or lever is the zoom level.",
+  "tags": [
+    "mod",
+    "QoL",
+    "controls",
+    "Camera",
+    "Map",
+    "zoom"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/NiJeTi/NoAbsoluteZoom"
+    }
+  ],
+  "authors": [
+    "NiJeTi"
+  ],
+  "isClientOrServer": "Client",
+  "githubOwner": "NiJeTi",
+  "githubRepoName": "NoAbsoluteZoom",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "NoAbsoluteZoom.dll",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/NiJeTi/NoAbsoluteZoom/releases/download/v1.0.0/NoAbsoluteZoom.dll",
+      "hash": "sha256:8f669bef6cce12b4bbc45621e19a9d064469e05c1bfc2eb4c874a06da4343e1c"
+    }
+  ]
+}


### PR DESCRIPTION
Registers [NoAbsoluteZoom](https://github.com/NiJeTi/NoAbsoluteZoom) — a client-side BepInEx 5 plugin for Nuclear Option that makes the `Zoom View` bind absolute: the position of a throttle slider or lever *is* the zoom level, in the cockpit and on the maximised map, instead of nudging it up and down like vanilla does.

**Mod ID:** `NoAbsoluteZoom` (matches the plugin's AssemblyName and the file name)

### Artifact
- Release: [v1.0.0](https://github.com/NiJeTi/NoAbsoluteZoom/releases/tag/v1.0.0), single asset `NoAbsoluteZoom.dll`
- `sha256:8f669bef6cce12b4bbc45621e19a9d064469e05c1bfc2eb4c874a06da4343e1c` (verified against the downloaded asset)
- Version matches the DLL's assembly metadata (1.0.0)
- `gameVersion`: 0.34.2
- No dependencies beyond BepInEx 5 itself
- `autoUpdateArtifacts` enabled

### Acceptance Policy
- Fully open source under MIT, no obfuscation: https://github.com/NiJeTi/NoAbsoluteZoom
- One mod per repository, delivered as a GitHub release asset
- Tag follows `vX.Y.Z`
- Client-side and visual only — no effect on the server
