### PR TITLE
Add Meridian Works

### DIFF
--- a/modManifests/MeridianWorks.json
+++ b/modManifests/MeridianWorks.json
@@ -1,0 +1,39 @@
+{
+  "id": "MeridianWorks",
+  "displayName": "Meridian Works",
+  "description": "A guided air to ground weapon pack from the Meridian Combine, an arms exporter that sells to both sides. The AGM-84 Warhawk is a 660 kg optical seeker with a datalink, locked on before release and needing nothing afterwards, out to 20 km. The AGM-57L Bulldog is a 520 kg laser round with a big blast warhead at 15 km. The AGM-33L Hornet is a 300 kg laser round for helicopters and light attack aircraft at 12 km. Carried on pylons as singles, twins and triples, and in bays up to six rounds. Carrying any Meridian mount raises the aircraft's lased target limit to six, as a floor rather than a bonus, so it will not compound with another mod that raises the same limit. Requires Blueprinter. The asset bundle ships inside the DLL, so it is one file.",
+  "tags": [
+    "mod",
+    "Weapon",
+    "blueprinter"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/mosdef31/NO-Meridian-Works/blob/main/README.md"
+    }
+  ],
+  "authors": [
+    "mosdef31"
+  ],
+  "githubOwner": "mosdef31",
+  "githubRepoName": "NO-Meridian-Works",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "MeridianWorksMod.dll",
+      "version": "1.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/mosdef31/NO-Meridian-Works/releases/download/v1.0.0/MeridianWorksMod.dll",
+      "hash": "sha256:49ddd397e56dc332b0ba5592a4386acd1f4dbc7cda126bf169ec5d907376f6af",
+      "dependencies": [
+        {
+          "id": "com.nikkorap.blueprinter",
+          "version": "1.8.21"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a manifest for Meridian Works v1.0.0, a guided air to ground weapon pack.

Requires Blueprinter. The asset bundle ships inside the DLL, so it is a single file and the entry is `type: plugin`.

Repo: https://github.com/mosdef31/NO-Meridian-Works
Release: https://github.com/mosdef31/NO-Meridian-Works/releases/tag/v1.0.0