### PR TITLE
Update AGR31Tenpin gameVersion to 0.34.2

### DIFF
--- a/modManifests/AGR31Tenpin.json
+++ b/modManifests/AGR31Tenpin.json
@@ -25,7 +25,7 @@
       "version": "1.1.0",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.34",
+      "gameVersion": "0.34.2",
       "downloadUrl": "https://github.com/mosdef31/NO-AGR-31-Tenpin/releases/download/v1.1.0/TenpinMod.dll",
       "hash": "sha256:55112d6b6782286e0dd00db8c5cfe86ea1581643fc1c26604b0875527af97950",
       "dependencies": [


### PR DESCRIPTION
Updates the newest artifact of `AGR31Tenpin` (v1.1.0) from `gameVersion` `0.34` to `0.34.2`.

The mod has been rebuilt and tested against Nuclear Option 0.34.2. Older artifacts are left at `0.34` unchanged.

One file, one line.