### PR TITLE
Add F-117A Nighthawk

### DIFF
--- a/modManifests/blacknight2u.f117a.nighthawk.json
+++ b/modManifests/blacknight2u.f117a.nighthawk.json
@@ -1,0 +1,44 @@
+{
+  "id": "blacknight2u.f117a.nighthawk",
+  "displayName": "F-117A Nighthawk",
+  "description": "Adds a rank 4 F-117A stealth strike aircraft with dynamic radar signature, passive targeting, a burst-limited onboard jammer, default-mission requisition support, detailed damage, and Nighthawk Black and Farewell Flag liveries. Includes expanded internal precision-strike, anti-radar, anti-ship, and defensive air-to-air loadouts. Automatically defers production management to Equalizer when active. Requires Blueprinter and matching versions in multiplayer.",
+  "tags": [
+    "mod",
+    "aircraft",
+    "blueprinter",
+    "stealth",
+    "multiplayer"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/blacknight2u/nuclear-option-f117"
+    }
+  ],
+  "authors": [
+    "blacknight2u"
+  ],
+  "imageUrl": "https://raw.githubusercontent.com/blacknight2u/nuclear-option-f117/main/Store/F117A-Nighthawk-NOMM.png",
+  "imageHash": "952aa4b8999ca8f427ddf9fd66522dcd462430cdee0773c892f5025099c276bf",
+  "isClientOrServer": "Both",
+  "githubOwner": "blacknight2u",
+  "githubRepoName": "nuclear-option-f117",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "F-117A-Nighthawk-v0.4.88.zip",
+      "version": "0.4.88",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/blacknight2u/nuclear-option-f117/releases/download/v0.4.88/F-117A-Nighthawk-v0.4.88.zip",
+      "hash": "sha256:0f71e0342fba4a6a765222a673fdf0e2fbbd3d1bd0197d96fa0f6dcce6c32312",
+      "dependencies": [
+        {
+          "id": "com.nikkorap.blueprinter",
+          "version": "1.8.21"
+        }
+      ]
+    }
+  ]
+}

--- a/modManifests/blacknight2u.f117a.nighthawk.json
+++ b/modManifests/blacknight2u.f117a.nighthawk.json
@@ -26,13 +26,13 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "F-117A-Nighthawk-v0.4.89.zip",
-      "version": "0.4.89",
+      "fileName": "F-117A-Nighthawk-v0.4.90.zip",
+      "version": "0.4.90",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.34.2",
-      "downloadUrl": "https://github.com/blacknight2u/nuclear-option-f117/releases/download/v0.4.89/F-117A-Nighthawk-v0.4.89.zip",
-      "hash": "sha256:cb1db3022dc6113b3bf4eadba91644f1859040300c016e6cc994c8a2707d1fc0",
+      "downloadUrl": "https://github.com/blacknight2u/nuclear-option-f117/releases/download/v0.4.90/F-117A-Nighthawk-v0.4.90.zip",
+      "hash": "sha256:9947641c9be635be081b2c6b2dc54beaf44c364ddaa2725827475c0475d7a1b0",
       "dependencies": [
         {
           "id": "com.nikkorap.blueprinter",

--- a/modManifests/blacknight2u.f117a.nighthawk.json
+++ b/modManifests/blacknight2u.f117a.nighthawk.json
@@ -1,7 +1,7 @@
 {
   "id": "blacknight2u.f117a.nighthawk",
   "displayName": "F-117A Nighthawk",
-  "description": "Adds a rank 4 F-117A stealth strike aircraft with dynamic radar signature, passive targeting, a burst-limited onboard jammer, default-mission requisition support, detailed damage, and Nighthawk Black and Farewell Flag liveries. Includes expanded internal precision-strike, anti-radar, anti-ship, and defensive air-to-air loadouts. Automatically defers production management to Equalizer when active. Requires Blueprinter and matching versions in multiplayer.",
+  "description": "Radar couldn't see the aircraft. It saw the bird perched on it. The legendary F-117A Nighthawk brings extreme stealth to Nuclear Option—built to penetrate the heaviest air defenses, strike unseen, and vanish before the enemy can respond. Available in Nighthawk Black and Farewell Flag liveries.",
   "tags": [
     "mod",
     "aircraft",
@@ -26,13 +26,13 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
-      "fileName": "F-117A-Nighthawk-v0.4.88.zip",
-      "version": "0.4.88",
+      "fileName": "F-117A-Nighthawk-v0.4.89.zip",
+      "version": "0.4.89",
       "category": "release",
       "type": "plugin",
       "gameVersion": "0.34.2",
-      "downloadUrl": "https://github.com/blacknight2u/nuclear-option-f117/releases/download/v0.4.88/F-117A-Nighthawk-v0.4.88.zip",
-      "hash": "sha256:0f71e0342fba4a6a765222a673fdf0e2fbbd3d1bd0197d96fa0f6dcce6c32312",
+      "downloadUrl": "https://github.com/blacknight2u/nuclear-option-f117/releases/download/v0.4.89/F-117A-Nighthawk-v0.4.89.zip",
+      "hash": "sha256:cb1db3022dc6113b3bf4eadba91644f1859040300c016e6cc994c8a2707d1fc0",
       "dependencies": [
         {
           "id": "com.nikkorap.blueprinter",


### PR DESCRIPTION
## Summary

Registers **F-117A Nighthawk** (`blacknight2u.f117a.nighthawk`) in NOMNOM.

The mod adds a separate rank 4 stealth strike aircraft with dynamic bay/gear radar signature, passive targeting, a burst-limited stock jammer, normal-mission requisition support, detailed damage, multiple internal loadouts, and Nighthawk Black/Farewell Flag liveries. It does not replace a stock aircraft.

## Release

- Version: `0.4.88`
- Nuclear Option: `0.34.2`
- Blueprinter dependency: `1.8.21`
- Runtime scope: client and server (`Both`)
- Release asset: `F-117A-Nighthawk-v0.4.88.zip`
- SHA-256: `0f71e0342fba4a6a765222a673fdf0e2fbbd3d1bd0197d96fa0f6dcce6c32312`
- Public MIT-licensed source: https://github.com/blacknight2u/nuclear-option-f117

## Validation

- Current NOMNOM JSON schema passes
- Mod ID is unique and matches the manifest filename
- Registered Blueprinter dependency/version matches the current catalog
- Repository, image, and release artifact URLs return successfully
- GitHub release digest matches the submitted artifact hash
- Pull request contains only the new mod manifest