### PR TITLE
Allow existing mod updates; correct Radar Missile Control compatibility

### DIFF
--- a/.github/workflows/validateJson.yml
+++ b/.github/workflows/validateJson.yml
@@ -30,11 +30,13 @@ jobs:
         run: |
           # The output is a space-separated string; we split it into an array
           $files = "${{ steps.changed-files.outputs.all_changed_files }}" -split " "
+          $addedFiles = "${{ steps.changed-files.outputs.added_files }}" -split " "
           $currentManifest = (get-content ".\manifest\manifest.json" | ConvertFrom-Json) | Group-Object id -AsHashTable
           foreach ($file in $files) {
               Write-Host "Processing file: $file"
+              $allowExistingId = $file -notin $addedFiles
               
               # If your script is a PowerShell script (.ps1):
               .\Validate-JsonSchema.ps1 -JsonPath "$file" -SchemaPath .\ValidationSchema.json
-              .\Validate-JsonContent.ps1 -Path "$file" -ModManifestHashTable $currentManifest
+              .\Validate-JsonContent.ps1 -Path "$file" -ModManifestHashTable $currentManifest -AllowExistingId:$allowExistingId
           }

--- a/Validate-JsonContent.ps1
+++ b/Validate-JsonContent.ps1
@@ -1,4 +1,4 @@
-Param($Path,$ModManifestHashTable)
+Param($Path,$ModManifestHashTable,[switch]$AllowExistingId)
  
 $errorString = $null
 if (!$(Test-Path $Path))
@@ -148,8 +148,8 @@ try
     #$parsedMod
 
     Write-Host "Validating Id matches file name: $($parsedMod.id) $((get-item $Path).Name): $(Validate-IdMatchesFileName -id $parsedMod.id)"
-    $isIdUnique = Validate-IdAlreadyExists -id $parsedMod.Id
-    Write-Host "Validating Id is Unique: $($parsedMod.id): $isIdUnique"
+    $isIdUnique = $AllowExistingId -or (Validate-IdAlreadyExists -id $parsedMod.Id)
+    Write-Host "Validating Id is Unique or an Existing Update: $($parsedMod.id): $isIdUnique"
     if (!$isIdUnique)
     {
         Write-Host $("Id $($parsedMod.id) is NOT UNIQUE!")

--- a/modManifests/blacknight2u.sarhcontrol.json
+++ b/modManifests/blacknight2u.sarhcontrol.json
@@ -29,7 +29,7 @@
       "version": "0.5.2",
       "category": "release",
       "type": "plugin",
-      "gameVersion": "0.34.1",
+      "gameVersion": "0.34.2",
       "downloadUrl": "https://github.com/blacknight2u/NuclearOption-RadarMissileControl/releases/download/v0.5.2/SARHControl-v0.5.2.zip",
       "hash": "sha256:24215328d5b8a41542fe877bd081e5689be41017fa5183bbe7536ec8de30ddf6"
     },


### PR DESCRIPTION
Fixes pull-request validation for normal updates to registered mods and corrects Radar Missile Control v0.5.2 compatibility metadata. Modified manifests may retain their registered ID, while newly added manifests must still use an ID absent from the compiled catalog. Upstream automation already imported the v0.5.2 artifact and F-117A updates, so those redundant changes were removed during the rebase. Radar Missile Control v0.5.2 was verified against Nuclear Option 0.34.2; its release URL and SHA-256 digest remain unchanged. Local schema and content validation pass.