### PR TITLE
Add ChaseCamPlus, HeliBinds and MouseDPI

### DIFF
--- a/modManifests/ChaseCamPlus.json
+++ b/modManifests/ChaseCamPlus.json
@@ -1,0 +1,34 @@
+{
+  "id": "ChaseCamPlus",
+  "displayName": "ChaseCamPlus",
+  "description": "Makes the chase camera usable on mouse and keyboard: a virtual joystick in third person, hold-to-orbit free look, a cockpit/chase toggle, the flight HUD and minimap restored in chase with per-element toggles, turret aiming, and an optional chase camera that keeps the horizon level.",
+  "tags": [
+    "mod",
+    "QoL",
+    "HUD"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/CarloApri/NO-ChaseCamPlus/blob/main/README.md"
+    }
+  ],
+  "authors": [
+    "CarloApri"
+  ],
+  "isClientOrServer": "Client",
+  "githubOwner": "CarloApri",
+  "githubRepoName": "NO-ChaseCamPlus",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "ChaseCamPlus.dll",
+      "version": "2.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/CarloApri/NO-ChaseCamPlus/releases/download/2.0.0/ChaseCamPlus.dll",
+      "hash": "sha256:259cd6f69804b68691e20a4e41800db32c5f4daab85e44358b25b0c1221672cf"
+    }
+  ]
+}

--- a/modManifests/HeliBinds.json
+++ b/modManifests/HeliBinds.json
@@ -1,0 +1,33 @@
+{
+  "id": "HeliBinds",
+  "displayName": "HeliBinds",
+  "description": "Separate flight controls for rotorcraft. Bind pitch, roll, yaw, collective and the brake differently on helicopters than on fixed-wing, and the game switches between them by itself.",
+  "tags": [
+    "mod",
+    "QoL"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/CarloApri/NO-HeliBinds/blob/main/README.md"
+    }
+  ],
+  "authors": [
+    "CarloApri"
+  ],
+  "isClientOrServer": "Client",
+  "githubOwner": "CarloApri",
+  "githubRepoName": "NO-HeliBinds",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "HeliBinds.dll",
+      "version": "2.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/CarloApri/NO-HeliBinds/releases/download/2.0.0/HeliBinds.dll",
+      "hash": "sha256:9a052051a0d563ea1b76fefa60d7ef51cf0721e0cafc58ec189832df1c867b54"
+    }
+  ]
+}

--- a/modManifests/MouseDPI.json
+++ b/modManifests/MouseDPI.json
@@ -1,0 +1,33 @@
+{
+  "id": "MouseDPI",
+  "displayName": "MouseDPI",
+  "description": "Scales the mouse input driving the virtual joystick past the sensitivity slider's ceiling, configured as the DPI your mouse has and the DPI you would like it to behave as.",
+  "tags": [
+    "mod",
+    "QoL"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/CarloApri/NO-MouseDPI/blob/main/README.md"
+    }
+  ],
+  "authors": [
+    "CarloApri"
+  ],
+  "isClientOrServer": "Client",
+  "githubOwner": "CarloApri",
+  "githubRepoName": "NO-MouseDPI",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "MouseDPI.dll",
+      "version": "2.0.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/CarloApri/NO-MouseDPI/releases/download/2.0.0/MouseDPI.dll",
+      "hash": "sha256:ebf280e432360ac02535eeee6873458c8ac0371ef3c657d8a8c0671d1e087a66"
+    }
+  ]
+}


### PR DESCRIPTION
Three client-side BepInEx plugins for mouse-and-keyboard play, each in its own repository.

| Mod | Repository | Version |
| --- | --- | --- |
| ChaseCamPlus | https://github.com/CarloApri/NO-ChaseCamPlus | 2.0.0 |
| HeliBinds | https://github.com/CarloApri/NO-HeliBinds | 2.0.0 |
| MouseDPI | https://github.com/CarloApri/NO-MouseDPI | 2.0.0 |

- **ChaseCamPlus** — makes the chase camera usable on mouse and keyboard: virtual joystick in third person, hold-to-orbit free look, cockpit/chase toggle, flight HUD and minimap restored in chase with per-element toggles, turret aiming, and an optional chase camera that keeps the horizon level.
- **HeliBinds** — separate flight controls for rotorcraft: pitch, roll, yaw, collective and brake bound differently on helicopters than on fixed-wing, switched automatically per aircraft.
- **MouseDPI** — scales the mouse input driving the virtual joystick past the sensitivity slider's ceiling, configured as the DPI your mouse has and the DPI you would like it to behave as.

All three are MIT licensed with the source public and unobfuscated, one mod per repository, built against BepInEx 5.4.23.5 and tested on game version 0.34.2. Each release ships a single `.dll` as its only asset. `autoUpdateArtifacts` is enabled on all three.