### PR TITLE
Update KaceyTronic-RWR to v1.4.0

### DIFF
--- a/modManifests/KaceyTronic-RWR.json
+++ b/modManifests/KaceyTronic-RWR.json
@@ -22,6 +22,15 @@
   "autoUpdateArtifacts": "True",
   "artifacts": [
     {
+      "fileName": "KaceyTronic-RWR-1.4.0.dll",
+      "version": "1.4.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/KcTries/KaceyTronic-RWR/releases/download/v1.4.0/KaceyTronic-RWR-1.4.0.dll",
+      "hash": "sha256:d38ce26fea39bbf53f0165a8a52e0909e37946761d8a2442bf038bfc58b1fb40"
+    },
+    {
       "fileName": "KaceyTronic-RWR-1.3.0.dll",
       "version": "1.3.0",
       "category": "release",


### PR DESCRIPTION
Adds the v1.4.0 artifact entry for KaceyTronic-RWR (existing entry kept for history).

## Changed
- Threat Panel is now referred to as Billboard.
- The diagonal divider on the Hi/Lo on the default Billboard now stays off until a Hi or Lo lamp is triggered.

## Fixed
- MSL warning being stuck on after dying, in some cases.

## Added
- Compact Billboard Toggle — a smaller and more stylized version of the Billboard.
- RWR and Billboard Scale settings (ConfigManager).
- Hide Minimap Option.
- Support for Aryx's new airframe, the OA-27 Cavalier (Rank 0 RWR, like the Cricket).

Full release notes: https://github.com/KcTries/KaceyTronic-RWR/releases/tag/v1.4.0