### PR TITLE
Add Oritasy listing (rename catalog id from com.iallemege.oritasy)

### DIFF
--- a/modManifests/Oritasy.json
+++ b/modManifests/Oritasy.json
@@ -1,0 +1,62 @@
+{
+  "id": "Oritasy",
+  "displayName": "Oritasy",
+  "description": "Nuclear Option gameplay pack: hangar aircraft, flight assists, HUD tools, WeXon weapons, TGM-85. Standard Edition (EN/ZH). Copy zip contents into BepInEx/plugins. Replaces the old com.iallemege.oritasy listing. Do not also load the D edition (same plugin GUID).",
+  "tags": [
+    "Aircraft",
+    "QoL",
+    "Weapons"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/iallemege/Oritasy-System"
+    }
+  ],
+  "authors": [
+    "IAllemege",
+    "qiaochen"
+  ],
+  "githubOwner": "iallemege",
+  "githubRepoName": "Oritasy-System",
+  "autoUpdateArtifacts": "True",
+  "isClientOrServer": "Both",
+  "artifacts": [
+    {
+      "type": "plugin",
+      "fileName": "Oritasy_0.0.9.211.zip",
+      "downloadUrl": "https://github.com/iallemege/Oritasy-System/releases/download/0.0.9.211/Oritasy_0.0.9.211.zip",
+      "hash": "sha256:b1f0aafc49f4ec56631bc59d61e5c73dc2eb752a28278cd0a0d190486f2991d2",
+      "gameVersion": "0.34.2",
+      "version": "0.0.9.211",
+      "category": "release"
+    },
+    {
+      "fileName": "Oritasy_0.0.9.207C.zip",
+      "version": "0.0.9.207",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/iallemege/Oritasy-System/releases/download/0.0.9.207/Oritasy_0.0.9.207C.zip",
+      "hash": "sha256:db45fad9cc10756af8325f679cd7dcf842bab04e1368a449344c9ec8303a5f38"
+    },
+    {
+      "fileName": "Oritasy_0.0.9.203C.zip",
+      "version": "0.0.9.203",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/iallemege/Oritasy-System/releases/download/0.0.9.203/Oritasy_0.0.9.203C.zip",
+      "hash": "sha256:93741bc46c037bfb8953d7d2d83440d402181edf26405140b6270b6037b211b8"
+    },
+    {
+      "type": "plugin",
+      "fileName": "Oritasy_0.0.9.197C.zip",
+      "downloadUrl": "https://github.com/iallemege/Oritasy-System/releases/download/0.0.9.197C/Oritasy_0.0.9.197C.zip",
+      "hash": "sha256:e250c7f8b3d0e44c27d3ec62bd8dd7eb8da6d91f3637e4387a005f3387b8a330",
+      "gameVersion": "0.34.2",
+      "version": "0.0.9.197",
+      "category": "release"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a new listing **Oritasy** (`modManifests/Oritasy.json`) so NOMM shows the name **Oritasy** instead of `com.iallemege.oritasy`
- Same GitHub repo / zip as before: https://github.com/iallemege/Oritasy-System/releases/tag/0.0.9.211
- BepInEx plugin GUID stays `com.iallemege.oritasy` (game load is unchanged)

Please retire `modManifests/com.iallemege.oritasy.json` after this merges so the catalog does not list the same pack twice. This PR does not delete that file: uniqueness CI fails on updates to existing ids, and validating a deleted path also fails.

## Test plan
- [ ] Schema / uniqueness CI passes (`Oritasy` is a new id)
- [ ] NOMM shows **Oritasy**
- [ ] Download URL and sha256 match the GitHub release asset
