### PR TITLE
Add Quartermaster

### DIFF
--- a/modManifests/QuartermasterMod.json
+++ b/modManifests/QuartermasterMod.json
@@ -1,0 +1,34 @@
+{
+  "id": "QuartermasterMod",
+  "displayName": "Quartermaster",
+  "description": "Adds your own options to the convoy purchase menu, read from a quartermaster.json that sits beside the DLL. Write a list a name, a cooldown, an optional icon and the unit ids it contains, and it appears in the donate menu priced off the units themselves. Lists can be grouped into sections and restricted to particular factions. Includes an in-game editor that lists every ground vehicle in the game and writes the file for you. In multiplayer everyone uses the host's file: the host publishes a fingerprint of its list and a player whose list disagrees loses their custom options for the mission rather than buying the wrong bundle.",
+  "tags": [
+    "mod",
+    "QoL",
+    "Server"
+  ],
+  "urls": [
+    {
+      "name": "info",
+      "url": "https://github.com/mosdef31/NO-Quartermaster/blob/main/README.md"
+    }
+  ],
+  "authors": [
+    "mosdef31"
+  ],
+  "isClientOrServer": "Both",
+  "githubOwner": "mosdef31",
+  "githubRepoName": "NO-Quartermaster",
+  "autoUpdateArtifacts": "True",
+  "artifacts": [
+    {
+      "fileName": "QuartermasterMod.zip",
+      "version": "1.2.2",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/mosdef31/NO-Quartermaster/releases/download/v1.2.2/QuartermasterMod.zip",
+      "hash": "sha256:4b5273c9d525ffc2d1881429e885bb2b66dc43885188a1fd00322f4f698d5cb1"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a manifest for **Quartermaster**, a QoL mod that lets you add your own options to the convoy purchase menu from a `quartermaster.json` beside the DLL.

- Repo: https://github.com/mosdef31/NO-Quartermaster
- Release: v1.2.2, game version 0.34.2
- Artifact: `QuartermasterMod.zip` (DLL plus a starter list file), sha256 `4b5273c9d525ffc2d1881429e885bb2b66dc43885188a1fd00322f4f698d5cb1`
- BepInEx 5, no other dependencies

The download URL was fetched anonymously and the hash matches.