### PR TITLE
Update MusicRandomizer to 0.3.0

### DIFF
--- a/modManifests/MusicRandomizer.json
+++ b/modManifests/MusicRandomizer.json
@@ -1,7 +1,7 @@
 {
   "id": "MusicRandomizer",
   "displayName": "Music Randomizer",
-  "description": "Replays and randomizes aircraft takeoff music, with a configurable cooldown between aircraft songs.",
+  "description": "Replays and randomizes aircraft takeoff music, with song selection and a configurable cooldown between aircraft songs.",
   "tags": [
     "QoL",
     "Flavor"
@@ -19,6 +19,15 @@
   "githubRepoName": "NuclearOptionMusicRandomizer",
   "autoUpdateArtifacts": "True",
   "artifacts": [
+    {
+      "fileName": "MusicRandomizer.dll",
+      "version": "0.3.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34",
+      "downloadUrl": "https://github.com/lucaspevidor/NuclearOptionMusicRandomizer/releases/download/v0.3.0/MusicRandomizer.dll",
+      "hash": "sha256:fb07a6c1549720d8c8d056780d97f6bf867749099aed06082a1265f78dd959ca"
+    },
     {
       "fileName": "MusicRandomizer.dll",
       "version": "0.2.0",


### PR DESCRIPTION
## Summary

Updates the MusicRandomizer listing added in #228 to version 0.3.0.

This release adds song checkboxes to BepInEx Configuration Manager. Players can exclude takeoff tracks, and their choices are saved and applied without restarting. The update has been tested in game.

The manifest lists 0.3.0 first and keeps the 0.2.0 artifact. The description now mentions song selection. Game compatibility, automatic updates, and the managed download count are unchanged.

## Release

- Version: `0.3.0`
- Type: BepInEx plugin
- Game version: `0.34` (unchanged)
- Repository: https://github.com/lucaspevidor/NuclearOptionMusicRandomizer
- Release: https://github.com/lucaspevidor/NuclearOptionMusicRandomizer/releases/tag/v0.3.0

## Validation

- The upstream JSON schema validator passes.
- Downloaded the published DLL and confirmed its version and SHA-256 match the manifest.
- The remaining content checks pass when the existing MusicRandomizer entry is excluded from the duplicate-ID lookup.

CI passes schema validation, then reports `Id MusicRandomizer is NOT UNIQUE!` because this mod is already registered. The [validation log](https://github.com/KopterBuzz/NOMNOM/actions/runs/34084373614/job/101625483016) confirms the same duplicate-ID failure seen locally. This is an update to the existing listing, so its ID needs to stay the same. This PR does not change the validator or generated registry files.
