### PR TITLE
Add NoWingmen 1.1.0 artifact with InputFramework dependency

### DIFF
--- a/modManifests/NoWingmen.json
+++ b/modManifests/NoWingmen.json
@@ -27,6 +27,21 @@
   "artifacts": [
     {
       "fileName": "NoWingmen.dll",
+      "version": "1.1.0",
+      "category": "release",
+      "type": "plugin",
+      "gameVersion": "0.34.2",
+      "downloadUrl": "https://github.com/NiJeTi/NoWingmen/releases/download/v1.1.0/NoWingmen.dll",
+      "hash": "sha256:2ca77a98984d4247fb53c1edd76b57dec540cc720d1313e8c1209b7555df5905",
+      "dependencies": [
+        {
+          "id": "InputFramework",
+          "version": "0.0.2"
+        }
+      ]
+    },
+    {
+      "fileName": "NoWingmen.dll",
       "version": "1.0.1",
       "category": "release",
       "type": "plugin",


### PR DESCRIPTION
Registers the 1.1.0 release of NoWingmen and its new dependency on Extra Input Framework.

### Why the dependency

1.1.0 adds keybind registration through Extra Input Framework — `Plugin.cs` carries `[BepInDependency(Controls.InputFrameworkGuid)]` with no minimum version, so it is a hard dependency. Declared against `InputFramework` `0.0.2`, the only version currently in the registry.

The requirement is new in 1.1.0. The `1.0.1` and `1.0.0` artifacts are untouched and correctly carry no dependency.

### Artifact

`hash` is GitHub's digest for the release asset, verified locally with `shasum -a 256` against the downloaded file.

The release is currently a **draft**, so the download URL is live only once it is published — which will happen immediately on merge. Sequencing it this way keeps the hourly job from auto-adding a 1.1.0 artifact before the dependency is registered, since `Update-ModArtifact.ps1` copies `dependencies` from `artifacts[0]`.
