### PR TITLE
Update NoSmoothTime description and tags

### DIFF
--- a/modManifests/NoSmoothTime.json
+++ b/modManifests/NoSmoothTime.json
@@ -1,7 +1,7 @@
 {
   "id": "NoSmoothTime",
   "displayName": "NoSmoothTime",
-  "description": "Smooth per-frame global lighting for dynamic day-night cycles.",
+  "description": "Smooth global lighting for dynamic day-night cycles and night skipping.",
   "tags": [
     "mod",
     "QoL",

--- a/modManifests/NoSmoothTime.json
+++ b/modManifests/NoSmoothTime.json
@@ -6,7 +6,9 @@
     "mod",
     "QoL",
     "Visual",
-    "lighting"
+    "lighting",
+    "night",
+    "time"
   ],
   "urls": [
     {


### PR DESCRIPTION
Updates the `NoSmoothTime` manifest to cover the night skipping feature added in v1.2.0, alongside the existing lighting smoothing.

Description before:
> Smooth per-frame global lighting for dynamic day-night cycles.

Description after:
> Smooth global lighting for dynamic day-night cycles and night skipping.

Also adds the `night` and `time` tags.

The artifact entry is left untouched for the auto-updater.
